### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir("Mosek")

### DIFF
--- a/src/Mosek.jl
+++ b/src/Mosek.jl
@@ -1,5 +1,5 @@
 module Mosek
-  if isfile(joinpath(Pkg.dir("Mosek"),"deps","deps.jl"))
+  if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
     include("../deps/deps.jl")
   else
     error("Mosek not properly installed. Please run Pkg.build(\"Mosek\")")

--- a/test/testexamples.jl
+++ b/test/testexamples.jl
@@ -6,5 +6,5 @@ include("../examples/milo1.jl")
 include("../examples/sdo1.jl")
 include("../examples/nlo1.jl")
 
-push!(ARGS, "$(Pkg.dir())/Mosek/examples/feasrepair.lp")
+push!(ARGS, "$(dirname(dirname(@__FILE__)))/examples/feasrepair.lp")
 include("../examples/feasrepairex1.jl")


### PR DESCRIPTION
this allows installing in a non-default location