### PR TITLE
Fixed provides command for libmosekscopt on OSX

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -37,6 +37,7 @@ mskplatform,distroext =
 # 1. Is MOSEKBINDIR set? If so this must point to the binaries dir in the MOSEK DISTRO  
 if haskey(ENV,"MOSEKBINDIR")
   provides(Binaries, ENV["MOSEKBINDIR"], libmosek)
+  provides(Binaries, ENV["MOSEKBINDIR"], libmosekscopt)
 
 # 2a. Otherwise, use the default installation path (Linux)
 elseif haskey(ENV,"HOME") && isdir(joinpath(ENV["HOME"],"mosek","7","tools","platform",mskplatform))


### PR DESCRIPTION
Hi,

After adding the environment variable MOSEKBINDIR, I added line 40 to provide "libmosekscopt" in order to make the package build correctly under my OSX system. Before that, I got the error that I couldn't install the dependency  "libmosekscopt" when I tried to install the package.

I think this problem may be encountered by several people using OSX and this could be one way to solve it.

Please let me know if you think this could be merged.

Best,
Bartolomeo
