### PR TITLE
Fix build methoderror

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -65,7 +65,7 @@ else
     end
     
     libdir(p::LessSimpleBuild,dep::BinDeps.LibraryDependency) = p.path
-    provides(::Type{LessSimpleBuild},steps,path::ASCIIString,dep; opts...) = provides(LessSimpleBuild(steps,path),dep; opts...)
+    provides(::Type{LessSimpleBuild},steps,path::AbstractString,dep; opts...) = provides(LessSimpleBuild(steps,path),dep; opts...)
     generate_steps(dep::BinDeps.LibraryDependency,h::LessSimpleBuild,opts) = h.steps
 
 


### PR DESCRIPTION
Before:

```
julia> Pkg.build("Mosek")
INFO: Building Mosek
==============================================================================================================[ ERROR: Mosek ]==============================================================================================================

LoadError: MethodError: `provides` has no method matching provides(::Type{__anon__.LessSimpleBuild}, ::BinDeps.GetSources, ::UTF8String, ::BinDeps.LibraryDependency)
Closest candidates are:
  provides{T}(::Type{T}, ::Any, ::UTF8String, ::Any)
  provides(::Type{__anon__.LessSimpleBuild}, ::Any, ::ASCIIString, ::Any)
  provides{T}(::Type{T}, ::Any, ::BinDeps.LibraryDependency)
  ...

while loading /Users/eric/.julia/v0.4/Mosek/deps/build.jl, in expression starting on line 76

============================================================================================================================================================================================================================================

==============================================================================================================[ BUILD ERRORS ]==============================================================================================================

WARNING: Mosek had build errors.

 - packages with build errors remain installed in /Users/eric/.julia/v0.4
 - build the package(s) and all dependencies with `Pkg.build("Mosek")`
 - build a single package by running its `deps/build.jl` script

============================================================================================================================================================================================================================================
```

After:

```
julia> Pkg.build("Mosek")
INFO: Building Mosek

WARNING: deprecated syntax "[a=>b, ...]" at /Users/eric/.julia/v0.4/Mosek/deps/build.jl:90.
Use "Dict(a=>b, ...)" instead.
WARNING: [a,b] concatenation is deprecated; use [a;b] instead
 in depwarn at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in oldstyle_vcat_warning at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in vect at abstractarray.jl:29
 in _find_library at /Users/eric/.julia/v0.4/BinDeps/src/dependencies.jl:449
 in satisfy! at /Users/eric/.julia/v0.4/BinDeps/src/dependencies.jl:735 (repeats 2 times)
 in anonymous at /Users/eric/.julia/v0.4/BinDeps/src/dependencies.jl:790
 in include at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in include_from_node1 at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in evalfile at loading.jl:168 (repeats 2 times)
 in anonymous at pkg/entry.jl:624
 in cd at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in build! at pkg/entry.jl:623
 in build at pkg/entry.jl:635
 in anonymous at pkg/dir.jl:28
 in cd at file.jl:20
 in cd at pkg/dir.jl:28
 in build at pkg.jl:62
WARNING: [a,b] concatenation is deprecated; use [a;b] instead
 in depwarn at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in oldstyle_vcat_warning at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in vect at abstractarray.jl:29
 in _find_library at /Users/eric/.julia/v0.4/BinDeps/src/dependencies.jl:449
 in anonymous at /Users/eric/.julia/v0.4/BinDeps/src/dependencies.jl:791
 in include at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in include_from_node1 at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in evalfile at loading.jl:168 (repeats 2 times)
 in anonymous at pkg/entry.jl:624
 in cd at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in build! at pkg/entry.jl:623
 in build at pkg/entry.jl:635
 in anonymous at pkg/dir.jl:28
 in cd at file.jl:20
 in cd at pkg/dir.jl:28
 in build at pkg.jl:62
```