### PR TITLE
Fix to build change to support v0.3

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,6 +6,8 @@ import BinDeps.generate_steps
 
 @BinDeps.setup
 
+StringType = VERSION < v"0.4.0-dev" ? String : AbstractString
+
 # define current version:
 mskvmajor = "7"
 mskvminor = "1"
@@ -65,7 +67,7 @@ else
     end
     
     libdir(p::LessSimpleBuild,dep::BinDeps.LibraryDependency) = p.path
-    provides(::Type{LessSimpleBuild},steps,path::AbstractString,dep; opts...) = provides(LessSimpleBuild(steps,path),dep; opts...)
+    provides(::Type{LessSimpleBuild},steps,path::StringType,dep; opts...) = provides(LessSimpleBuild(steps,path),dep; opts...)
     generate_steps(dep::BinDeps.LibraryDependency,h::LessSimpleBuild,opts) = h.steps
 
 


### PR DESCRIPTION
AbstractString was String in v0.3

Thanks @tkelman for pointing that out.