### PR TITLE
compat fixes for julia 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.3.2
 MathProgBase 0.3.7 0.4.0-
+Compat

--- a/src/Mosek.jl
+++ b/src/Mosek.jl
@@ -5,6 +5,9 @@ module Mosek
     error("Mosek not properly installed. Please run Pkg.build(\"Mosek\")")
   end
 
+  using Compat
+  import MathProgBase
+
 
   export
     makeenv, maketask,

--- a/src/MosekConicInterface.jl
+++ b/src/MosekConicInterface.jl
@@ -27,7 +27,7 @@ msk_accepted_cones = [:Free,
 # vecsize
 #   Total number of scalar element (= numlin+numqconeelm+numsdpconeelm)
 #
-function countcones{Tis}(cones :: Array{(Symbol,Tis),1})
+function countcones{Tis}(cones :: Array{@compat(Tuple{Symbol,Tis}),1})
     numlin        = 0 # linear and conic quadratic elements
     numsdpcone    = 0 # number of sdp cones
     numsdpconeelm = 0 # total number of elements in all sdp cones
@@ -209,8 +209,8 @@ function loadconicproblem!(m::MosekMathProgModel,c,A,b,constr_cones,var_cones)
                       convert(SparseMatrixCSC{Float64,Int},reshape(c,(length(c),1))),
                       convert(SparseMatrixCSC{Float64,Int},A),
                       convert(Array{Float64,1},b),
-                      convert(Array{(Symbol,Any),1},constr_cones),
-                      convert(Array{(Symbol,Any),1},var_cones))
+                      convert(Array{@compat(Tuple{Symbol,Any}),1},constr_cones),
+                      convert(Array{@compat(Tuple{Symbol,Any}),1},var_cones))
 end
 
 
@@ -218,8 +218,8 @@ function loadconicproblem!(m::MosekMathProgModel,
                            c::SparseMatrixCSC{Float64,Int},
                            A::SparseMatrixCSC{Float64,Int},
                            b::Array{Float64,1},
-                           constr_cones::Array{(Symbol,Any),1},
-                           var_cones   ::Array{(Symbol,Any),1})
+                           constr_cones::Array{@compat(Tuple{Symbol,Any}),1},
+                           var_cones   ::Array{@compat(Tuple{Symbol,Any}),1})
     # check data
     const N = c.m
     const M = length(b)

--- a/src/MosekSolverInterface.jl
+++ b/src/MosekSolverInterface.jl
@@ -1,5 +1,6 @@
 module MosekMathProgSolverInterface
 using ..Mosek
+using Compat
 
 export MosekSolver
 

--- a/src/msk_functions.jl
+++ b/src/msk_functions.jl
@@ -1923,7 +1923,7 @@ function getsolsta(task_:: MSKtask,whichsol_:: Int32)
   (convert(Int32,solsta_[1]))
 end
 
-function getsolution(task_:: MSKtask,whichsol_:: Int32)
+function MathProgBase.SolverInterface.getsolution(task_:: MSKtask,whichsol_:: Int32)
   prosta_ = Array(Int32,(1,))
   solsta_ = Array(Int32,(1,))
   __tmp_var_0 = getnumcon(task_)

--- a/test/mathprogtest.jl
+++ b/test/mathprogtest.jl
@@ -1,6 +1,6 @@
 using Mosek
 using MathProgBase
-using MathProgBase.MathProgSolverInterface
+using MathProgBase.SolverInterface
 
 include(joinpath(Pkg.dir("MathProgBase"),"test","linprog.jl"))
 include(joinpath(Pkg.dir("MathProgBase"),"test","quadprog.jl"))


### PR DESCRIPTION
With these changes, the package runs and passes tests on 0.4. (There are still tons of deprecation warnings.) The only messy part is that there were separate Mosek and MPB versions of the function ``getsolution``. Julia 0.4 is more strict about this, so I merged the two methods. 

Ref #47.