### PR TITLE
Fix function call deprecation warnings.

### DIFF
--- a/src/MosekSolverInterface.jl
+++ b/src/MosekSolverInterface.jl
@@ -269,14 +269,14 @@ function loadproblem!(m::     MosekMathProgModel,
   nothing
 end
 
-function loadproblem! (m::     MosekMathProgModel,
-                       A,
-                       collb,
-                       colub,
-                       obj,
-                       rowlb,
-                       rowub,
-                       sense :: Symbol)
+function loadproblem!(m::     MosekMathProgModel,
+                      A,
+                      collb,
+                      colub,
+                      obj,
+                      rowlb,
+                      rowub,
+                      sense :: Symbol)
 
   loadproblem!(m,
                convert(SparseMatrixCSC{Float64,Int},sparse(A)),
@@ -656,9 +656,9 @@ function getsense(m::MosekMathProgModel)
   end
 end
 
-numvar       (m::MosekMathProgModel) = m.numvar
-numconstr    (m::MosekMathProgModel) = m.numcon+m.numqcon
-numlinconstr (m::MosekMathProgModel) = m.numcon
+numvar(       m::MosekMathProgModel) = m.numvar
+numconstr(    m::MosekMathProgModel) = m.numcon+m.numqcon
+numlinconstr( m::MosekMathProgModel) = m.numcon
 numquadconstr(m::MosekMathProgModel) = m.numqcon
 optimize!(m::MosekMathProgModel) = 
     begin

--- a/src/msk_callback.jl
+++ b/src/msk_callback.jl
@@ -4,7 +4,7 @@ export
 
 function msk_stream_callback_wrapper(userdata::Ptr{Void}, msg :: Ptr{Uint8})
   f = unsafe_pointer_to_objref(userdata) :: Function
-  f (bytestring(msg))
+  f(bytestring(msg))
   convert(Int32,0)::Int32
 end
 

--- a/src/msk_functions.jl
+++ b/src/msk_functions.jl
@@ -313,7 +313,7 @@ function analyzenames(task_:: MSKtask,whichstream_:: Int32,nametype_:: Int32)
   res = @msk_ccall( "analyzenames",Int32,(Ptr{Void},Int32,Int32,),task_.task,whichstream_,nametype_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -321,7 +321,7 @@ function analyzeproblem(task_:: MSKtask,whichstream_:: Int32)
   res = @msk_ccall( "analyzeproblem",Int32,(Ptr{Void},Int32,),task_.task,whichstream_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -329,7 +329,7 @@ function analyzesolution(task_:: MSKtask,whichstream_:: Int32,whichsol_:: Int32)
   res = @msk_ccall( "analyzesolution",Int32,(Ptr{Void},Int32,Int32,),task_.task,whichstream_,whichsol_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -339,7 +339,7 @@ function appendbarvars(task_:: MSKtask,dim_:: Array{Int32})
   res = @msk_ccall( "appendbarvars",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,num_,dim_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -349,7 +349,7 @@ function appendcone(task_:: MSKtask,conetype_:: Int32,conepar_:: Float64,submem_
   res = @msk_ccall( "appendcone",Int32,(Ptr{Void},Int32,Float64,Int32,Ptr{Int32},),task_.task,conetype_,conepar_,nummem_,submem_ .- 1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -358,7 +358,7 @@ function appendconeseq(task_:: MSKtask,conetype_:: Int32,conepar_:: Float64,numm
   res = @msk_ccall( "appendconeseq",Int32,(Ptr{Void},Int32,Float64,Int32,Int32,),task_.task,conetype_,conepar_,nummem_,j_-1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -368,7 +368,7 @@ function appendconesseq(task_:: MSKtask,conetype_:: Array{Int32},conepar_:: Arra
   res = @msk_ccall( "appendconesseq",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Float64},Ptr{Int32},Int32,),task_.task,num_,conetype_,conepar_,nummem_,j_-1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -377,7 +377,7 @@ function appendcons(task_:: MSKtask,num_:: Int32)
   res = @msk_ccall( "appendcons",Int32,(Ptr{Void},Int32,),task_.task,num_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -399,7 +399,7 @@ function appendsparsesymmat(task_:: MSKtask,
   res = @msk_ccall( "appendsparsesymmat",Int32,(Ptr{Void},Int32,Int64,Ptr{Int32},Ptr{Int32},Ptr{Float64},Ptr{Int64},),task_.task,dim_,nz_,subi_ .- 1,subj_ .- 1,valij_,idx_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,idx_[1]+1))
 end
@@ -408,7 +408,7 @@ function appendstat(task_:: MSKtask)
   res = @msk_ccall( "appendstat",Int32,(Ptr{Void},),task_.task)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -417,7 +417,7 @@ function appendvars(task_:: MSKtask,num_:: Int32)
   res = @msk_ccall( "appendvars",Int32,(Ptr{Void},Int32,),task_.task,num_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -427,7 +427,7 @@ function basiscond(task_:: MSKtask)
   res = @msk_ccall( "basiscond",Int32,(Ptr{Void},Ptr{Float64},Ptr{Float64},),task_.task,nrmbasis_,nrminvbasis_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Float64,nrmbasis_[1]),convert(Float64,nrminvbasis_[1]))
 end
@@ -437,7 +437,7 @@ function bktostr(task_:: MSKtask,bk_:: Int32)
   res = @msk_ccall( "bktostr",Int32,(Ptr{Void},Int32,Ptr{Uint8},),task_.task,bk_,str_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(str_))
 end
@@ -446,7 +446,7 @@ function callbackcodetostr(code_:: Int32)
   callbackcodestr_ = zeros(Uint8,MSK_MAX_STR_LEN)
   res = @msk_ccall( "callbackcodetostr",Int32,(Int32,Ptr{Uint8},),code_,callbackcodestr_)
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
   (bytestring(callbackcodestr_))
 end
@@ -455,7 +455,7 @@ function checkconvexity(task_:: MSKtask)
   res = @msk_ccall( "checkconvexity",Int32,(Ptr{Void},),task_.task)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -464,7 +464,7 @@ function checkmem(task_:: MSKtask,file_:: String,line_:: Int32)
   res = @msk_ccall( "checkmemtask",Int32,(Ptr{Void},Ptr{UInt8},Int32,),task_.task,bytestring(file_),line_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -473,7 +473,7 @@ function chgbound(task_:: MSKtask,accmode_:: Int32,i_:: Int32,lower_:: Int32,fin
   res = @msk_ccall( "chgbound",Int32,(Ptr{Void},Int32,Int32,Int32,Int32,Float64,),task_.task,accmode_,i_-1,lower_,finite_,value_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -481,7 +481,7 @@ function commitchanges(task_:: MSKtask)
   res = @msk_ccall( "commitchanges",Int32,(Ptr{Void},),task_.task)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -490,7 +490,7 @@ function conetypetostr(task_:: MSKtask,conetype_:: Int32)
   res = @msk_ccall( "conetypetostr",Int32,(Ptr{Void},Int32,Ptr{Uint8},),task_.task,conetype_,str_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(str_))
 end
@@ -499,7 +499,7 @@ function deletesolution(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "deletesolution",Int32,(Ptr{Void},Int32,),task_.task,whichsol_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -517,7 +517,7 @@ function dualsensitivity(task_:: MSKtask,subj_:: Array{Int32})
   res = @msk_ccall( "dualsensitivity",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},),task_.task,numj_,subj_ .- 1,__tmp_var_1,__tmp_var_3,__tmp_var_5,__tmp_var_7)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1,__tmp_var_3,__tmp_var_5,__tmp_var_7)
 end
@@ -532,7 +532,7 @@ function getacol(task_:: MSKtask,j_:: Int32)
   res = @msk_ccall( "getacol",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,j_-1,nzj_,__tmp_var_1,__tmp_var_3)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,nzj_[1]),__tmp_var_1,__tmp_var_3)
 end
@@ -543,7 +543,7 @@ function getacolnumnz(task_:: MSKtask,i_:: Int32)
   res = @msk_ccall( "getacolnumnz",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,i_-1,nzj_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,nzj_[1]))
 end
@@ -561,7 +561,7 @@ function getacolslicetrip(task_:: MSKtask,first_:: Int32,last_:: Int32)
   res = @msk_ccall( "getacolslicetrip",Int32,(Ptr{Void},Int32,Int32,Int64,Ptr{Int64},Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,first_-1,last_-1,maxnumnz_,&surp_,__tmp_var_1,__tmp_var_3,__tmp_var_5)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1,__tmp_var_3,__tmp_var_5)
 end
@@ -572,7 +572,7 @@ function getaij(task_:: MSKtask,i_:: Int32,j_:: Int32)
   res = @msk_ccall( "getaij",Int32,(Ptr{Void},Int32,Int32,Ptr{Float64},),task_.task,i_-1,j_-1,aij_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Float64,aij_[1]))
 end
@@ -583,7 +583,7 @@ function getapiecenumnz(task_:: MSKtask,firsti_:: Int32,lasti_:: Int32,firstj_::
   res = @msk_ccall( "getapiecenumnz",Int32,(Ptr{Void},Int32,Int32,Int32,Int32,Ptr{Int32},),task_.task,firsti_-1,lasti_-1,firstj_-1,lastj_-1,numnz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,numnz_[1]))
 end
@@ -598,7 +598,7 @@ function getarow(task_:: MSKtask,i_:: Int32)
   res = @msk_ccall( "getarow",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,i_-1,nzi_,__tmp_var_1,__tmp_var_3)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,nzi_[1]),__tmp_var_1,__tmp_var_3)
 end
@@ -609,7 +609,7 @@ function getarownumnz(task_:: MSKtask,i_:: Int32)
   res = @msk_ccall( "getarownumnz",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,i_-1,nzi_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,nzi_[1]))
 end
@@ -627,7 +627,7 @@ function getarowslicetrip(task_:: MSKtask,first_:: Int32,last_:: Int32)
   res = @msk_ccall( "getarowslicetrip",Int32,(Ptr{Void},Int32,Int32,Int64,Ptr{Int64},Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,first_-1,last_-1,maxnumnz_,&surp_,__tmp_var_1,__tmp_var_3,__tmp_var_5)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1,__tmp_var_3,__tmp_var_5)
 end
@@ -647,7 +647,7 @@ function getaslice(task_:: MSKtask,accmode_:: Int32,first_:: Int32,last_:: Int32
   res = @msk_ccall( "getaslice64",Int32,(Ptr{Void},Int32,Int32,Int32,Int64,Ptr{Int64},Ptr{Int64},Ptr{Int64},Ptr{Int32},Ptr{Float64},),task_.task,accmode_,first_-1,last_-1,maxnumnz_,&surp_,__tmp_var_1,__tmp_var_3,__tmp_var_5,__tmp_var_7)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1,__tmp_var_3,__tmp_var_5,__tmp_var_7)
 end
@@ -658,7 +658,7 @@ function getaslicenumnz(task_:: MSKtask,accmode_:: Int32,first_:: Int32,last_:: 
   res = @msk_ccall( "getaslicenumnz64",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Int64},),task_.task,accmode_,first_-1,last_-1,numnz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,numnz_[1]))
 end
@@ -679,7 +679,7 @@ function getbarablocktriplet(task_:: MSKtask)
   res = @msk_ccall( "getbarablocktriplet",Int32,(Ptr{Void},Int64,Ptr{Int64},Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,maxnum_,num_,__tmp_var_1,__tmp_var_3,__tmp_var_5,__tmp_var_7,__tmp_var_9)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,num_[1]),__tmp_var_1,__tmp_var_3,__tmp_var_5,__tmp_var_7,__tmp_var_9)
 end
@@ -697,7 +697,7 @@ function getbaraidx(task_:: MSKtask,idx_:: Int64)
   res = @msk_ccall( "getbaraidx",Int32,(Ptr{Void},Int64,Int64,Ptr{Int32},Ptr{Int32},Ptr{Int64},Ptr{Int64},Ptr{Float64},),task_.task,idx_-1,maxnum_,i_,j_,num_,__tmp_var_1,__tmp_var_3)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,i_[1]+1),convert(Int32,j_[1]+1),convert(Int64,num_[1]),__tmp_var_1,__tmp_var_3)
 end
@@ -709,7 +709,7 @@ function getbaraidxij(task_:: MSKtask,idx_:: Int64)
   res = @msk_ccall( "getbaraidxij",Int32,(Ptr{Void},Int64,Ptr{Int32},Ptr{Int32},),task_.task,idx_-1,i_,j_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,i_[1]+1),convert(Int32,j_[1]+1))
 end
@@ -720,7 +720,7 @@ function getbaraidxinfo(task_:: MSKtask,idx_:: Int64)
   res = @msk_ccall( "getbaraidxinfo",Int32,(Ptr{Void},Int64,Ptr{Int64},),task_.task,idx_-1,num_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,num_[1]))
 end
@@ -733,7 +733,7 @@ function getbarasparsity(task_:: MSKtask)
   res = @msk_ccall( "getbarasparsity",Int32,(Ptr{Void},Int64,Ptr{Int64},Ptr{Int64},),task_.task,maxnumnz_,numnz_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,numnz_[1]),__tmp_var_1)
 end
@@ -752,7 +752,7 @@ function getbarcblocktriplet(task_:: MSKtask)
   res = @msk_ccall( "getbarcblocktriplet",Int32,(Ptr{Void},Int64,Ptr{Int64},Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,maxnum_,num_,__tmp_var_1,__tmp_var_3,__tmp_var_5,__tmp_var_7)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,num_[1]),__tmp_var_1,__tmp_var_3,__tmp_var_5,__tmp_var_7)
 end
@@ -769,7 +769,7 @@ function getbarcidx(task_:: MSKtask,idx_:: Int64)
   res = @msk_ccall( "getbarcidx",Int32,(Ptr{Void},Int64,Int64,Ptr{Int32},Ptr{Int64},Ptr{Int64},Ptr{Float64},),task_.task,idx_-1,maxnum_,j_,num_,__tmp_var_1,__tmp_var_3)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,j_[1]+1),convert(Int64,num_[1]),__tmp_var_1,__tmp_var_3)
 end
@@ -780,7 +780,7 @@ function getbarcidxinfo(task_:: MSKtask,idx_:: Int64)
   res = @msk_ccall( "getbarcidxinfo",Int32,(Ptr{Void},Int64,Ptr{Int64},),task_.task,idx_-1,num_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,num_[1]))
 end
@@ -791,7 +791,7 @@ function getbarcidxj(task_:: MSKtask,idx_:: Int64)
   res = @msk_ccall( "getbarcidxj",Int32,(Ptr{Void},Int64,Ptr{Int32},),task_.task,idx_-1,j_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,j_[1]+1))
 end
@@ -804,7 +804,7 @@ function getbarcsparsity(task_:: MSKtask)
   res = @msk_ccall( "getbarcsparsity",Int32,(Ptr{Void},Int64,Ptr{Int64},Ptr{Int64},),task_.task,maxnumnz_,numnz_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,numnz_[1]),__tmp_var_1)
 end
@@ -816,7 +816,7 @@ function getbarsj(task_:: MSKtask,whichsol_:: Int32,j_:: Int32)
   res = @msk_ccall( "getbarsj",Int32,(Ptr{Void},Int32,Int32,Ptr{Float64},),task_.task,whichsol_,j_-1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -828,7 +828,7 @@ function getbarvarname(task_:: MSKtask,i_:: Int32)
   res = @msk_ccall( "getbarvarname",Int32,(Ptr{Void},Int32,Int32,Ptr{Uint8},),task_.task,i_-1,maxlen_,name_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(name_))
 end
@@ -839,7 +839,7 @@ function getbarvarnameindex(task_:: MSKtask,somename_:: String)
   res = @msk_ccall( "getbarvarnameindex",Int32,(Ptr{Void},Ptr{UInt8},Ptr{Int32},Ptr{Int32},),task_.task,bytestring(somename_),asgn_,index_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,asgn_[1]),convert(Int32,index_[1]))
 end
@@ -850,7 +850,7 @@ function getbarvarnamelen(task_:: MSKtask,i_:: Int32)
   res = @msk_ccall( "getbarvarnamelen",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,i_-1,len_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,len_[1]))
 end
@@ -862,7 +862,7 @@ function getbarxj(task_:: MSKtask,whichsol_:: Int32,j_:: Int32)
   res = @msk_ccall( "getbarxj",Int32,(Ptr{Void},Int32,Int32,Ptr{Float64},),task_.task,whichsol_,j_-1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -875,7 +875,7 @@ function getbound(task_:: MSKtask,accmode_:: Int32,i_:: Int32)
   res = @msk_ccall( "getbound",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},Ptr{Float64},),task_.task,accmode_,i_-1,bk_,bl_,bu_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,bk_[1]),convert(Float64,bl_[1]),convert(Float64,bu_[1]))
 end
@@ -891,7 +891,7 @@ function getboundslice(task_:: MSKtask,accmode_:: Int32,first_:: Int32,last_:: I
   res = @msk_ccall( "getboundslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Int32},Ptr{Float64},Ptr{Float64},),task_.task,accmode_,first_-1,last_-1,bk_,__tmp_var_2,__tmp_var_4)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bk_,__tmp_var_2,__tmp_var_4)
 end
@@ -902,7 +902,7 @@ function getc(task_:: MSKtask)
   res = @msk_ccall( "getc",Int32,(Ptr{Void},Ptr{Float64},),task_.task,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -912,7 +912,7 @@ function getcfix(task_:: MSKtask)
   res = @msk_ccall( "getcfix",Int32,(Ptr{Void},Ptr{Float64},),task_.task,cfix_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Float64,cfix_[1]))
 end
@@ -923,7 +923,7 @@ function getcj(task_:: MSKtask,j_:: Int32)
   res = @msk_ccall( "getcj",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,j_-1,cj_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Float64,cj_[1]))
 end
@@ -936,7 +936,7 @@ function getconbound(task_:: MSKtask,i_:: Int32)
   res = @msk_ccall( "getconbound",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Float64},Ptr{Float64},),task_.task,i_-1,bk_,bl_,bu_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,bk_[1]),convert(Float64,bl_[1]),convert(Float64,bu_[1]))
 end
@@ -952,7 +952,7 @@ function getconboundslice(task_:: MSKtask,first_:: Int32,last_:: Int32)
   res = @msk_ccall( "getconboundslice",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},Ptr{Float64},),task_.task,first_-1,last_-1,bk_,__tmp_var_2,__tmp_var_4)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bk_,__tmp_var_2,__tmp_var_4)
 end
@@ -967,7 +967,7 @@ function getcone(task_:: MSKtask,k_:: Int32)
   res = @msk_ccall( "getcone",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Float64},Ptr{Int32},Ptr{Int32},),task_.task,k_-1,conetype_,conepar_,nummem_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,conetype_[1]),convert(Float64,conepar_[1]),convert(Int32,nummem_[1]),__tmp_var_1)
 end
@@ -980,7 +980,7 @@ function getconeinfo(task_:: MSKtask,k_:: Int32)
   res = @msk_ccall( "getconeinfo",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Float64},Ptr{Int32},),task_.task,k_-1,conetype_,conepar_,nummem_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,conetype_[1]),convert(Float64,conepar_[1]),convert(Int32,nummem_[1]))
 end
@@ -992,7 +992,7 @@ function getconename(task_:: MSKtask,i_:: Int32)
   res = @msk_ccall( "getconename",Int32,(Ptr{Void},Int32,Int32,Ptr{Uint8},),task_.task,i_-1,maxlen_,name_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(name_))
 end
@@ -1003,7 +1003,7 @@ function getconenameindex(task_:: MSKtask,somename_:: String)
   res = @msk_ccall( "getconenameindex",Int32,(Ptr{Void},Ptr{UInt8},Ptr{Int32},Ptr{Int32},),task_.task,bytestring(somename_),asgn_,index_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,asgn_[1]),convert(Int32,index_[1]))
 end
@@ -1014,7 +1014,7 @@ function getconenamelen(task_:: MSKtask,i_:: Int32)
   res = @msk_ccall( "getconenamelen",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,i_-1,len_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,len_[1]))
 end
@@ -1026,7 +1026,7 @@ function getconname(task_:: MSKtask,i_:: Int32)
   res = @msk_ccall( "getconname",Int32,(Ptr{Void},Int32,Int32,Ptr{Uint8},),task_.task,i_-1,maxlen_,name_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(name_))
 end
@@ -1037,7 +1037,7 @@ function getconnameindex(task_:: MSKtask,somename_:: String)
   res = @msk_ccall( "getconnameindex",Int32,(Ptr{Void},Ptr{UInt8},Ptr{Int32},Ptr{Int32},),task_.task,bytestring(somename_),asgn_,index_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,asgn_[1]),convert(Int32,index_[1]))
 end
@@ -1048,7 +1048,7 @@ function getconnamelen(task_:: MSKtask,i_:: Int32)
   res = @msk_ccall( "getconnamelen",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,i_-1,len_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,len_[1]))
 end
@@ -1060,7 +1060,7 @@ function getcslice(task_:: MSKtask,first_:: Int32,last_:: Int32)
   res = @msk_ccall( "getcslice",Int32,(Ptr{Void},Int32,Int32,Ptr{Float64},),task_.task,first_-1,last_-1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1073,7 +1073,7 @@ function getdbi(task_:: MSKtask,whichsol_:: Int32,accmode_:: Int32,sub_:: Array{
   res = @msk_ccall( "getdbi",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Int32,Ptr{Float64},),task_.task,whichsol_,accmode_,sub_ .- 1,len_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1086,7 +1086,7 @@ function getdcni(task_:: MSKtask,whichsol_:: Int32,sub_:: Array{Int32})
   res = @msk_ccall( "getdcni",Int32,(Ptr{Void},Int32,Ptr{Int32},Int32,Ptr{Float64},),task_.task,whichsol_,sub_ .- 1,len_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1099,7 +1099,7 @@ function getdeqi(task_:: MSKtask,whichsol_:: Int32,accmode_:: Int32,sub_:: Array
   res = @msk_ccall( "getdeqi",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Int32,Ptr{Float64},Int32,),task_.task,whichsol_,accmode_,sub_ .- 1,len_,__tmp_var_1,normalize_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1110,7 +1110,7 @@ function getdimbarvarj(task_:: MSKtask,j_:: Int32)
   res = @msk_ccall( "getdimbarvarj",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,j_-1,dimbarvarj_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,dimbarvarj_[1]))
 end
@@ -1120,7 +1120,7 @@ function getdouinf(task_:: MSKtask,whichdinf_:: Int32)
   res = @msk_ccall( "getdouinf",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichdinf_,dvalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Float64,dvalue_[1]))
 end
@@ -1130,7 +1130,7 @@ function getdouparam(task_:: MSKtask,param_:: Int32)
   res = @msk_ccall( "getdouparam",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,param_,parvalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Float64,parvalue_[1]))
 end
@@ -1140,7 +1140,7 @@ function getdualobj(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getdualobj",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,dualobj_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Float64,dualobj_[1]))
 end
@@ -1153,7 +1153,7 @@ function getdviolbarvar(task_:: MSKtask,whichsol_:: Int32,sub_:: Array{Int32})
   res = @msk_ccall( "getdviolbarvar",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},),task_.task,whichsol_,num_,sub_ .- 1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1166,7 +1166,7 @@ function getdviolcon(task_:: MSKtask,whichsol_:: Int32,sub_:: Array{Int32})
   res = @msk_ccall( "getdviolcon",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},),task_.task,whichsol_,num_,sub_ .- 1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1179,7 +1179,7 @@ function getdviolcones(task_:: MSKtask,whichsol_:: Int32,sub_:: Array{Int32})
   res = @msk_ccall( "getdviolcones",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},),task_.task,whichsol_,num_,sub_ .- 1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1192,7 +1192,7 @@ function getdviolvar(task_:: MSKtask,whichsol_:: Int32,sub_:: Array{Int32})
   res = @msk_ccall( "getdviolvar",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},),task_.task,whichsol_,num_,sub_ .- 1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1202,7 +1202,7 @@ function getinfeasiblesubproblem(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getinfeasiblesubproblem",Int32,(Ptr{Void},Int32,Ptr{Ptr{Void}},),task_.task,whichsol_,inftask_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(MSKtask,inftask_[1]))
 end
@@ -1213,7 +1213,7 @@ function getinfname(task_:: MSKtask,inftype_:: Int32,whichinf_:: Int32)
   res = @msk_ccall( "getinfname",Int32,(Ptr{Void},Int32,Int32,Ptr{Uint8},),task_.task,inftype_,whichinf_,infname_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(infname_))
 end
@@ -1226,7 +1226,7 @@ function getinti(task_:: MSKtask,whichsol_:: Int32,sub_:: Array{Int32})
   res = @msk_ccall( "getinti",Int32,(Ptr{Void},Int32,Ptr{Int32},Int32,Ptr{Float64},),task_.task,whichsol_,sub_ .- 1,len_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1236,7 +1236,7 @@ function getintinf(task_:: MSKtask,whichiinf_:: Int32)
   res = @msk_ccall( "getintinf",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,whichiinf_,ivalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,ivalue_[1]))
 end
@@ -1246,7 +1246,7 @@ function getintparam(task_:: MSKtask,param_:: Int32)
   res = @msk_ccall( "getintparam",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,param_,parvalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,parvalue_[1]))
 end
@@ -1257,7 +1257,7 @@ function getlenbarvarj(task_:: MSKtask,j_:: Int32)
   res = @msk_ccall( "getlenbarvarj",Int32,(Ptr{Void},Int32,Ptr{Int64},),task_.task,j_-1,lenbarvarj_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,lenbarvarj_[1]))
 end
@@ -1267,7 +1267,7 @@ function getlintinf(task_:: MSKtask,whichliinf_:: Int32)
   res = @msk_ccall( "getlintinf",Int32,(Ptr{Void},Int32,Ptr{Int64},),task_.task,whichliinf_,ivalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,ivalue_[1]))
 end
@@ -1277,7 +1277,7 @@ function getmaxnumanz(task_:: MSKtask)
   res = @msk_ccall( "getmaxnumanz64",Int32,(Ptr{Void},Ptr{Int64},),task_.task,maxnumanz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,maxnumanz_[1]))
 end
@@ -1287,7 +1287,7 @@ function getmaxnumbarvar(task_:: MSKtask)
   res = @msk_ccall( "getmaxnumbarvar",Int32,(Ptr{Void},Ptr{Int32},),task_.task,maxnumbarvar_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,maxnumbarvar_[1]))
 end
@@ -1297,7 +1297,7 @@ function getmaxnumcon(task_:: MSKtask)
   res = @msk_ccall( "getmaxnumcon",Int32,(Ptr{Void},Ptr{Int32},),task_.task,maxnumcon_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,maxnumcon_[1]))
 end
@@ -1307,7 +1307,7 @@ function getmaxnumcone(task_:: MSKtask)
   res = @msk_ccall( "getmaxnumcone",Int32,(Ptr{Void},Ptr{Int32},),task_.task,maxnumcone_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,maxnumcone_[1]))
 end
@@ -1317,7 +1317,7 @@ function getmaxnumqnz(task_:: MSKtask)
   res = @msk_ccall( "getmaxnumqnz64",Int32,(Ptr{Void},Ptr{Int64},),task_.task,maxnumqnz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,maxnumqnz_[1]))
 end
@@ -1327,7 +1327,7 @@ function getmaxnumvar(task_:: MSKtask)
   res = @msk_ccall( "getmaxnumvar",Int32,(Ptr{Void},Ptr{Int32},),task_.task,maxnumvar_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,maxnumvar_[1]))
 end
@@ -1338,7 +1338,7 @@ function getmemusage(task_:: MSKtask)
   res = @msk_ccall( "getmemusagetask",Int32,(Ptr{Void},Ptr{Int64},Ptr{Int64},),task_.task,meminuse_,maxmemuse_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,meminuse_[1]),convert(Int64,maxmemuse_[1]))
 end
@@ -1348,7 +1348,7 @@ function getnadouinf(task_:: MSKtask,whichdinf_:: String)
   res = @msk_ccall( "getnadouinf",Int32,(Ptr{Void},Ptr{UInt8},Ptr{Float64},),task_.task,bytestring(whichdinf_),dvalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Float64,dvalue_[1]))
 end
@@ -1358,7 +1358,7 @@ function getnadouparam(task_:: MSKtask,paramname_:: String)
   res = @msk_ccall( "getnadouparam",Int32,(Ptr{Void},Ptr{UInt8},Ptr{Float64},),task_.task,bytestring(paramname_),parvalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Float64,parvalue_[1]))
 end
@@ -1368,7 +1368,7 @@ function getnaintinf(task_:: MSKtask,infitemname_:: String)
   res = @msk_ccall( "getnaintinf",Int32,(Ptr{Void},Ptr{UInt8},Ptr{Int32},),task_.task,bytestring(infitemname_),ivalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,ivalue_[1]))
 end
@@ -1378,7 +1378,7 @@ function getnaintparam(task_:: MSKtask,paramname_:: String)
   res = @msk_ccall( "getnaintparam",Int32,(Ptr{Void},Ptr{UInt8},Ptr{Int32},),task_.task,bytestring(paramname_),parvalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,parvalue_[1]))
 end
@@ -1390,7 +1390,7 @@ function getnastrparam(task_:: MSKtask,paramname_:: String,maxlen_:: Int32)
   res = @msk_ccall( "getnastrparam",Int32,(Ptr{Void},Ptr{UInt8},Int32,Ptr{Int32},Ptr{Uint8},),task_.task,bytestring(paramname_),maxlen_,len_,parvalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,len_[1]),bytestring(parvalue_))
 end
@@ -1400,7 +1400,7 @@ function getnumanz(task_:: MSKtask)
   res = @msk_ccall( "getnumanz",Int32,(Ptr{Void},Ptr{Int32},),task_.task,numanz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,numanz_[1]))
 end
@@ -1410,7 +1410,7 @@ function getnumanz64(task_:: MSKtask)
   res = @msk_ccall( "getnumanz64",Int32,(Ptr{Void},Ptr{Int64},),task_.task,numanz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,numanz_[1]))
 end
@@ -1420,7 +1420,7 @@ function getnumbarablocktriplets(task_:: MSKtask)
   res = @msk_ccall( "getnumbarablocktriplets",Int32,(Ptr{Void},Ptr{Int64},),task_.task,num_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,num_[1]))
 end
@@ -1430,7 +1430,7 @@ function getnumbaranz(task_:: MSKtask)
   res = @msk_ccall( "getnumbaranz",Int32,(Ptr{Void},Ptr{Int64},),task_.task,nz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,nz_[1]))
 end
@@ -1440,7 +1440,7 @@ function getnumbarcblocktriplets(task_:: MSKtask)
   res = @msk_ccall( "getnumbarcblocktriplets",Int32,(Ptr{Void},Ptr{Int64},),task_.task,num_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,num_[1]))
 end
@@ -1450,7 +1450,7 @@ function getnumbarcnz(task_:: MSKtask)
   res = @msk_ccall( "getnumbarcnz",Int32,(Ptr{Void},Ptr{Int64},),task_.task,nz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,nz_[1]))
 end
@@ -1460,7 +1460,7 @@ function getnumbarvar(task_:: MSKtask)
   res = @msk_ccall( "getnumbarvar",Int32,(Ptr{Void},Ptr{Int32},),task_.task,numbarvar_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,numbarvar_[1]))
 end
@@ -1470,7 +1470,7 @@ function getnumcon(task_:: MSKtask)
   res = @msk_ccall( "getnumcon",Int32,(Ptr{Void},Ptr{Int32},),task_.task,numcon_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,numcon_[1]))
 end
@@ -1480,7 +1480,7 @@ function getnumcone(task_:: MSKtask)
   res = @msk_ccall( "getnumcone",Int32,(Ptr{Void},Ptr{Int32},),task_.task,numcone_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,numcone_[1]))
 end
@@ -1491,7 +1491,7 @@ function getnumconemem(task_:: MSKtask,k_:: Int32)
   res = @msk_ccall( "getnumconemem",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,k_-1,nummem_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,nummem_[1]))
 end
@@ -1501,7 +1501,7 @@ function getnumintvar(task_:: MSKtask)
   res = @msk_ccall( "getnumintvar",Int32,(Ptr{Void},Ptr{Int32},),task_.task,numintvar_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,numintvar_[1]))
 end
@@ -1511,7 +1511,7 @@ function getnumparam(task_:: MSKtask,partype_:: Int32)
   res = @msk_ccall( "getnumparam",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,partype_,numparam_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,numparam_[1]))
 end
@@ -1522,7 +1522,7 @@ function getnumqconknz(task_:: MSKtask,k_:: Int32)
   res = @msk_ccall( "getnumqconknz",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,k_-1,numqcnz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,numqcnz_[1]))
 end
@@ -1533,7 +1533,7 @@ function getnumqconknz64(task_:: MSKtask,k_:: Int32)
   res = @msk_ccall( "getnumqconknz64",Int32,(Ptr{Void},Int32,Ptr{Int64},),task_.task,k_-1,numqcnz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,numqcnz_[1]))
 end
@@ -1543,7 +1543,7 @@ function getnumqobjnz(task_:: MSKtask)
   res = @msk_ccall( "getnumqobjnz64",Int32,(Ptr{Void},Ptr{Int64},),task_.task,numqonz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,numqonz_[1]))
 end
@@ -1553,7 +1553,7 @@ function getnumsymmat(task_:: MSKtask)
   res = @msk_ccall( "getnumsymmat",Int32,(Ptr{Void},Ptr{Int64},),task_.task,num_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,num_[1]))
 end
@@ -1563,7 +1563,7 @@ function getnumvar(task_:: MSKtask)
   res = @msk_ccall( "getnumvar",Int32,(Ptr{Void},Ptr{Int32},),task_.task,numvar_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,numvar_[1]))
 end
@@ -1574,7 +1574,7 @@ function getobjname(task_:: MSKtask)
   res = @msk_ccall( "getobjname",Int32,(Ptr{Void},Int32,Ptr{Uint8},),task_.task,maxlen_,objname_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(objname_))
 end
@@ -1584,7 +1584,7 @@ function getobjnamelen(task_:: MSKtask)
   res = @msk_ccall( "getobjnamelen",Int32,(Ptr{Void},Ptr{Int32},),task_.task,len_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,len_[1]))
 end
@@ -1594,7 +1594,7 @@ function getobjsense(task_:: MSKtask)
   res = @msk_ccall( "getobjsense",Int32,(Ptr{Void},Ptr{Int32},),task_.task,sense_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,sense_[1]))
 end
@@ -1605,7 +1605,7 @@ function getparamname(task_:: MSKtask,partype_:: Int32,param_:: Int32)
   res = @msk_ccall( "getparamname",Int32,(Ptr{Void},Int32,Int32,Ptr{Uint8},),task_.task,partype_,param_,parname_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(parname_))
 end
@@ -1618,7 +1618,7 @@ function getpbi(task_:: MSKtask,whichsol_:: Int32,accmode_:: Int32,sub_:: Array{
   res = @msk_ccall( "getpbi",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Int32,Ptr{Float64},Int32,),task_.task,whichsol_,accmode_,sub_ .- 1,len_,__tmp_var_1,normalize_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1631,7 +1631,7 @@ function getpcni(task_:: MSKtask,whichsol_:: Int32,sub_:: Array{Int32})
   res = @msk_ccall( "getpcni",Int32,(Ptr{Void},Int32,Ptr{Int32},Int32,Ptr{Float64},),task_.task,whichsol_,sub_ .- 1,len_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1644,7 +1644,7 @@ function getpeqi(task_:: MSKtask,whichsol_:: Int32,sub_:: Array{Int32},normalize
   res = @msk_ccall( "getpeqi",Int32,(Ptr{Void},Int32,Ptr{Int32},Int32,Ptr{Float64},Int32,),task_.task,whichsol_,sub_ .- 1,len_,__tmp_var_1,normalize_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1654,7 +1654,7 @@ function getprimalobj(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getprimalobj",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,primalobj_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Float64,primalobj_[1]))
 end
@@ -1664,7 +1664,7 @@ function getprobtype(task_:: MSKtask)
   res = @msk_ccall( "getprobtype",Int32,(Ptr{Void},Ptr{Int32},),task_.task,probtype_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,probtype_[1]))
 end
@@ -1674,7 +1674,7 @@ function getprosta(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getprosta",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,whichsol_,prosta_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,prosta_[1]))
 end
@@ -1687,7 +1687,7 @@ function getpviolbarvar(task_:: MSKtask,whichsol_:: Int32,sub_:: Array{Int32})
   res = @msk_ccall( "getpviolbarvar",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},),task_.task,whichsol_,num_,sub_ .- 1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1700,7 +1700,7 @@ function getpviolcon(task_:: MSKtask,whichsol_:: Int32,sub_:: Array{Int32})
   res = @msk_ccall( "getpviolcon",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},),task_.task,whichsol_,num_,sub_ .- 1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1713,7 +1713,7 @@ function getpviolcones(task_:: MSKtask,whichsol_:: Int32,sub_:: Array{Int32})
   res = @msk_ccall( "getpviolcones",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},),task_.task,whichsol_,num_,sub_ .- 1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1726,7 +1726,7 @@ function getpviolvar(task_:: MSKtask,whichsol_:: Int32,sub_:: Array{Int32})
   res = @msk_ccall( "getpviolvar",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},),task_.task,whichsol_,num_,sub_ .- 1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1745,7 +1745,7 @@ function getqconk(task_:: MSKtask,k_:: Int32)
   res = @msk_ccall( "getqconk64",Int32,(Ptr{Void},Int32,Int64,Ptr{Int64},Ptr{Int64},Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,k_-1,maxnumqcnz_,&qcsurp_,numqcnz_,__tmp_var_1,__tmp_var_3,__tmp_var_5)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,numqcnz_[1]),__tmp_var_1,__tmp_var_3,__tmp_var_5)
 end
@@ -1763,7 +1763,7 @@ function getqobj(task_:: MSKtask)
   res = @msk_ccall( "getqobj",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,maxnumqonz_,&qosurp_,numqonz_,__tmp_var_1,__tmp_var_3,__tmp_var_5)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,numqonz_[1]),__tmp_var_1,__tmp_var_3,__tmp_var_5)
 end
@@ -1781,7 +1781,7 @@ function getqobj64(task_:: MSKtask)
   res = @msk_ccall( "getqobj64",Int32,(Ptr{Void},Int64,Ptr{Int64},Ptr{Int64},Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,maxnumqonz_,&qosurp_,numqonz_,__tmp_var_1,__tmp_var_3,__tmp_var_5)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int64,numqonz_[1]),__tmp_var_1,__tmp_var_3,__tmp_var_5)
 end
@@ -1792,7 +1792,7 @@ function getqobjij(task_:: MSKtask,i_:: Int32,j_:: Int32)
   res = @msk_ccall( "getqobjij",Int32,(Ptr{Void},Int32,Int32,Ptr{Float64},),task_.task,i_-1,j_-1,qoij_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Float64,qoij_[1]))
 end
@@ -1804,7 +1804,7 @@ function getreducedcosts(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:
   res = @msk_ccall( "getreducedcosts",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1815,7 +1815,7 @@ function getskc(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getskc",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,whichsol_,skc_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (skc_)
 end
@@ -1827,7 +1827,7 @@ function getskcslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "getskcslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Int32},),task_.task,whichsol_,first_-1,last_-1,skc_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (skc_)
 end
@@ -1838,7 +1838,7 @@ function getskx(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getskx",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,whichsol_,skx_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (skx_)
 end
@@ -1850,7 +1850,7 @@ function getskxslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "getskxslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Int32},),task_.task,whichsol_,first_-1,last_-1,skx_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (skx_)
 end
@@ -1861,7 +1861,7 @@ function getslc(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getslc",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1873,7 +1873,7 @@ function getslcslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "getslcslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1884,7 +1884,7 @@ function getslx(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getslx",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1896,7 +1896,7 @@ function getslxslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "getslxslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1907,7 +1907,7 @@ function getsnx(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getsnx",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1919,7 +1919,7 @@ function getsnxslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "getsnxslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -1929,7 +1929,7 @@ function getsolsta(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getsolsta",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,whichsol_,solsta_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,solsta_[1]))
 end
@@ -1963,7 +1963,7 @@ function MathProgBase.SolverInterface.getsolution(task_:: MSKtask,whichsol_:: In
   res = @msk_ccall( "getsolution",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},),task_.task,whichsol_,prosta_,solsta_,skc_,skx_,skn_,__tmp_var_4,__tmp_var_6,__tmp_var_8,__tmp_var_10,__tmp_var_12,__tmp_var_14,__tmp_var_16,__tmp_var_18)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,prosta_[1]),convert(Int32,solsta_[1]),skc_,skx_,skn_,__tmp_var_4,__tmp_var_6,__tmp_var_8,__tmp_var_10,__tmp_var_12,__tmp_var_14,__tmp_var_16,__tmp_var_18)
 end
@@ -1978,7 +1978,7 @@ function getsolutioni(task_:: MSKtask,accmode_:: Int32,i_:: Int32,whichsol_:: In
   res = @msk_ccall( "getsolutioni",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Int32},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},),task_.task,accmode_,i_-1,whichsol_,sk_,x_,sl_,su_,sn_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,sk_[1]),convert(Float64,x_[1]),convert(Float64,sl_[1]),convert(Float64,su_[1]),convert(Float64,sn_[1]))
 end
@@ -1998,7 +1998,7 @@ function getsolutioninf(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getsolutioninf",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},),task_.task,whichsol_,prosta_,solsta_,primalobj_,maxpbi_,maxpcni_,maxpeqi_,maxinti_,dualobj_,maxdbi_,maxdcni_,maxdeqi_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,prosta_[1]),convert(Int32,solsta_[1]),convert(Float64,primalobj_[1]),convert(Float64,maxpbi_[1]),convert(Float64,maxpcni_[1]),convert(Float64,maxpeqi_[1]),convert(Float64,maxinti_[1]),convert(Float64,dualobj_[1]),convert(Float64,maxdbi_[1]),convert(Float64,maxdcni_[1]),convert(Float64,maxdeqi_[1]))
 end
@@ -2018,7 +2018,7 @@ function getsolutioninfo(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getsolutioninfo",Int32,(Ptr{Void},Int32,Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},),task_.task,whichsol_,pobj_,pviolcon_,pviolvar_,pviolbarvar_,pviolcone_,pviolitg_,dobj_,dviolcon_,dviolvar_,dviolbarvar_,dviolcone_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Float64,pobj_[1]),convert(Float64,pviolcon_[1]),convert(Float64,pviolvar_[1]),convert(Float64,pviolbarvar_[1]),convert(Float64,pviolcone_[1]),convert(Float64,pviolitg_[1]),convert(Float64,dobj_[1]),convert(Float64,dviolcon_[1]),convert(Float64,dviolvar_[1]),convert(Float64,dviolbarvar_[1]),convert(Float64,dviolcone_[1]))
 end
@@ -2030,7 +2030,7 @@ function getsolutionslice(task_:: MSKtask,whichsol_:: Int32,solitem_:: Int32,fir
   res = @msk_ccall( "getsolutionslice",Int32,(Ptr{Void},Int32,Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,solitem_,first_-1,last_-1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -2047,7 +2047,7 @@ function getsparsesymmat(task_:: MSKtask,idx_:: Int64)
   res = @msk_ccall( "getsparsesymmat",Int32,(Ptr{Void},Int64,Int64,Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,idx_-1,maxlen_,__tmp_var_1,__tmp_var_3,__tmp_var_5)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1,__tmp_var_3,__tmp_var_5)
 end
@@ -2059,7 +2059,7 @@ function getstrparam(task_:: MSKtask,param_:: Int32)
   res = @msk_ccall( "getstrparam",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Uint8},),task_.task,param_,maxlen_,len_,parvalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,len_[1]),bytestring(parvalue_))
 end
@@ -2069,7 +2069,7 @@ function getstrparamlen(task_:: MSKtask,param_:: Int32)
   res = @msk_ccall( "getstrparamlen",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,param_,len_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,len_[1]))
 end
@@ -2080,7 +2080,7 @@ function getsuc(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getsuc",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -2092,7 +2092,7 @@ function getsucslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "getsucslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -2103,7 +2103,7 @@ function getsux(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getsux",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -2115,7 +2115,7 @@ function getsuxslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "getsuxslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -2128,7 +2128,7 @@ function getsymmatinfo(task_:: MSKtask,idx_:: Int64)
   res = @msk_ccall( "getsymmatinfo",Int32,(Ptr{Void},Int64,Ptr{Int32},Ptr{Int64},Ptr{Int32},),task_.task,idx_-1,dim_,nz_,type_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,dim_[1]),convert(Int64,nz_[1]),convert(Int32,type_[1]))
 end
@@ -2139,7 +2139,7 @@ function gettaskname(task_:: MSKtask)
   res = @msk_ccall( "gettaskname",Int32,(Ptr{Void},Int32,Ptr{Uint8},),task_.task,maxlen_,taskname_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(taskname_))
 end
@@ -2149,7 +2149,7 @@ function gettasknamelen(task_:: MSKtask)
   res = @msk_ccall( "gettasknamelen",Int32,(Ptr{Void},Ptr{Int32},),task_.task,len_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,len_[1]))
 end
@@ -2162,7 +2162,7 @@ function getvarbound(task_:: MSKtask,i_:: Int32)
   res = @msk_ccall( "getvarbound",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Float64},Ptr{Float64},),task_.task,i_-1,bk_,bl_,bu_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,bk_[1]),convert(Float64,bl_[1]),convert(Float64,bu_[1]))
 end
@@ -2178,7 +2178,7 @@ function getvarboundslice(task_:: MSKtask,first_:: Int32,last_:: Int32)
   res = @msk_ccall( "getvarboundslice",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},Ptr{Float64},),task_.task,first_-1,last_-1,bk_,__tmp_var_2,__tmp_var_4)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bk_,__tmp_var_2,__tmp_var_4)
 end
@@ -2189,7 +2189,7 @@ function getvarbranchdir(task_:: MSKtask,j_:: Int32)
   res = @msk_ccall( "getvarbranchdir",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,j_-1,direction_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,direction_[1]))
 end
@@ -2200,7 +2200,7 @@ function getvarbranchpri(task_:: MSKtask,j_:: Int32)
   res = @msk_ccall( "getvarbranchpri",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,j_-1,priority_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,priority_[1]))
 end
@@ -2212,7 +2212,7 @@ function getvarname(task_:: MSKtask,j_:: Int32)
   res = @msk_ccall( "getvarname",Int32,(Ptr{Void},Int32,Int32,Ptr{Uint8},),task_.task,j_-1,maxlen_,name_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(name_))
 end
@@ -2223,7 +2223,7 @@ function getvarnameindex(task_:: MSKtask,somename_:: String)
   res = @msk_ccall( "getvarnameindex",Int32,(Ptr{Void},Ptr{UInt8},Ptr{Int32},Ptr{Int32},),task_.task,bytestring(somename_),asgn_,index_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,asgn_[1]),convert(Int32,index_[1]))
 end
@@ -2234,7 +2234,7 @@ function getvarnamelen(task_:: MSKtask,i_:: Int32)
   res = @msk_ccall( "getvarnamelen",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,i_-1,len_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,len_[1]))
 end
@@ -2245,7 +2245,7 @@ function getvartype(task_:: MSKtask,j_:: Int32)
   res = @msk_ccall( "getvartype",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,j_-1,vartype_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,vartype_[1]))
 end
@@ -2258,7 +2258,7 @@ function getvartypelist(task_:: MSKtask,subj_:: Array{Int32})
   res = @msk_ccall( "getvartypelist",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},),task_.task,num_,subj_ .- 1,vartype_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (vartype_)
 end
@@ -2269,7 +2269,7 @@ function getxc(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getxc",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -2281,7 +2281,7 @@ function getxcslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: Int
   res = @msk_ccall( "getxcslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -2292,7 +2292,7 @@ function getxx(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "getxx",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -2304,7 +2304,7 @@ function getxxslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: Int
   res = @msk_ccall( "getxxslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -2315,7 +2315,7 @@ function gety(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "gety",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -2327,7 +2327,7 @@ function getyslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: Int3
   res = @msk_ccall( "getyslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -2338,7 +2338,7 @@ function initbasissolve(task_:: MSKtask)
   res = @msk_ccall( "initbasissolve",Int32,(Ptr{Void},Ptr{Int32},),task_.task,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -2357,7 +2357,7 @@ function inputdata(task_:: MSKtask,maxnumcon_:: Int32,maxnumvar_:: Int32,c_:: Ar
   res = @msk_ccall( "inputdata64",Int32,(Ptr{Void},Int32,Int32,Int32,Int32,Ptr{Float64},Float64,Ptr{Int64},Ptr{Int64},Ptr{Int32},Ptr{Float64},Ptr{Int32},Ptr{Float64},Ptr{Float64},Ptr{Int32},Ptr{Float64},Ptr{Float64},),task_.task,maxnumcon_,maxnumvar_,numcon_,numvar_,c_,cfix_,aptrb_ .- 1,aptre_ .- 1,asub_ .- 1,aval_,bkc_,blc_,buc_,bkx_,blx_,bux_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2366,7 +2366,7 @@ function isdouparname(task_:: MSKtask,parname_:: String)
   res = @msk_ccall( "isdouparname",Int32,(Ptr{Void},Ptr{UInt8},Ptr{Int32},),task_.task,bytestring(parname_),param_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,param_[1]))
 end
@@ -2376,7 +2376,7 @@ function isintparname(task_:: MSKtask,parname_:: String)
   res = @msk_ccall( "isintparname",Int32,(Ptr{Void},Ptr{UInt8},Ptr{Int32},),task_.task,bytestring(parname_),param_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,param_[1]))
 end
@@ -2386,7 +2386,7 @@ function isstrparname(task_:: MSKtask,parname_:: String)
   res = @msk_ccall( "isstrparname",Int32,(Ptr{Void},Ptr{UInt8},Ptr{Int32},),task_.task,bytestring(parname_),param_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,param_[1]))
 end
@@ -2396,7 +2396,7 @@ function linkfiletostream(task_:: MSKtask,whichstream_:: Int32,filename_:: Strin
   res = @msk_ccall( "linkfiletotaskstream",Int32,(Ptr{Void},Int32,Ptr{UInt8},Int32,),task_.task,whichstream_,bytestring(filename_),append_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2404,7 +2404,7 @@ function onesolutionsummary(task_:: MSKtask,whichstream_:: Int32,whichsol_:: Int
   res = @msk_ccall( "onesolutionsummary",Int32,(Ptr{Void},Int32,Int32,),task_.task,whichstream_,whichsol_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2412,7 +2412,7 @@ function optimizersummary(task_:: MSKtask,whichstream_:: Int32)
   res = @msk_ccall( "optimizersummary",Int32,(Ptr{Void},Int32,),task_.task,whichstream_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2421,7 +2421,7 @@ function optimize(task_:: MSKtask)
   res = @msk_ccall( "optimizetrm",Int32,(Ptr{Void},Ptr{Int32},),task_.task,trmcode_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,trmcode_[1]))
 end
@@ -2451,7 +2451,7 @@ function primalrepair(task_:: MSKtask,wlc_:: Array{Float64},wuc_:: Array{Float64
   res = @msk_ccall( "primalrepair",Int32,(Ptr{Void},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},),task_.task,wlc_,wuc_,wlx_,wux_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2478,7 +2478,7 @@ function primalsensitivity(task_:: MSKtask,subi_:: Array{Int32},marki_:: Array{I
   res = @msk_ccall( "primalsensitivity",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},Int32,Ptr{Int32},Ptr{Int32},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},),task_.task,numi_,subi_ .- 1,marki_,numj_,subj_ .- 1,markj_,__tmp_var_1,__tmp_var_3,__tmp_var_5,__tmp_var_7,__tmp_var_9,__tmp_var_11,__tmp_var_13,__tmp_var_15)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1,__tmp_var_3,__tmp_var_5,__tmp_var_7,__tmp_var_9,__tmp_var_11,__tmp_var_13,__tmp_var_15)
 end
@@ -2488,7 +2488,7 @@ function printdata(task_:: MSKtask,whichstream_:: Int32,firsti_:: Int32,lasti_::
   res = @msk_ccall( "printdata",Int32,(Ptr{Void},Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,),task_.task,whichstream_,firsti_-1,lasti_-1,firstj_-1,lastj_-1,firstk_-1,lastk_-1,c_,qo_,a_,qc_,bc_,bx_,vartype_,cones_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2496,7 +2496,7 @@ function printparam(task_:: MSKtask)
   res = @msk_ccall( "printparam",Int32,(Ptr{Void},),task_.task)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2505,7 +2505,7 @@ function probtypetostr(task_:: MSKtask,probtype_:: Int32)
   res = @msk_ccall( "probtypetostr",Int32,(Ptr{Void},Int32,Ptr{Uint8},),task_.task,probtype_,str_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(str_))
 end
@@ -2515,7 +2515,7 @@ function prostatostr(task_:: MSKtask,prosta_:: Int32)
   res = @msk_ccall( "prostatostr",Int32,(Ptr{Void},Int32,Ptr{Uint8},),task_.task,prosta_,str_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(str_))
 end
@@ -2526,7 +2526,7 @@ function putacol(task_:: MSKtask,j_:: Int32,subj_:: Array{Int32},valj_:: Array{F
   res = @msk_ccall( "putacol",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},),task_.task,j_-1,nzj_,subj_ .- 1,valj_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2543,7 +2543,7 @@ function putacollist(task_:: MSKtask,sub_:: Array{Int32},ptrb_:: Array{Int64},pt
   res = @msk_ccall( "putacollist64",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int64},Ptr{Int64},Ptr{Int32},Ptr{Float64},),task_.task,num_,sub_ .- 1,ptrb_ .- 1,ptre_ .- 1,asub_ .- 1,aval_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2569,7 +2569,7 @@ function putacolslice(task_:: MSKtask,first_:: Int32,last_:: Int32,ptrb_:: Array
   res = @msk_ccall( "putacolslice64",Int32,(Ptr{Void},Int32,Int32,Ptr{Int64},Ptr{Int64},Ptr{Int32},Ptr{Float64},),task_.task,first_-1,last_-1,ptrb_ .- 1,ptre_ .- 1,asub_ .- 1,aval_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2578,7 +2578,7 @@ function putaij(task_:: MSKtask,i_:: Int32,j_:: Int32,aij_:: Float64)
   res = @msk_ccall( "putaij",Int32,(Ptr{Void},Int32,Int32,Float64,),task_.task,i_-1,j_-1,aij_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2588,7 +2588,7 @@ function putaijlist(task_:: MSKtask,subi_:: Array{Int32},subj_:: Array{Int32},va
   res = @msk_ccall( "putaijlist64",Int32,(Ptr{Void},Int64,Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,num_,subi_ .- 1,subj_ .- 1,valij_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2598,7 +2598,7 @@ function putarow(task_:: MSKtask,i_:: Int32,subi_:: Array{Int32},vali_:: Array{F
   res = @msk_ccall( "putarow",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},),task_.task,i_-1,nzi_,subi_ .- 1,vali_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2615,7 +2615,7 @@ function putarowlist(task_:: MSKtask,sub_:: Array{Int32},ptrb_:: Array{Int64},pt
   res = @msk_ccall( "putarowlist64",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int64},Ptr{Int64},Ptr{Int32},Ptr{Float64},),task_.task,num_,sub_ .- 1,ptrb_ .- 1,ptre_ .- 1,asub_ .- 1,aval_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2641,7 +2641,7 @@ function putarowslice(task_:: MSKtask,first_:: Int32,last_:: Int32,ptrb_:: Array
   res = @msk_ccall( "putarowslice64",Int32,(Ptr{Void},Int32,Int32,Ptr{Int64},Ptr{Int64},Ptr{Int32},Ptr{Float64},),task_.task,first_-1,last_-1,ptrb_ .- 1,ptre_ .- 1,asub_ .- 1,aval_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2675,7 +2675,7 @@ function putbarablocktriplet(task_:: MSKtask,num_:: Int64,subi_:: Array{Int32},s
   res = @msk_ccall( "putbarablocktriplet",Int32,(Ptr{Void},Int64,Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,num_,subi_ .- 1,subj_ .- 1,subk_ .- 1,subl_ .- 1,valijkl_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2685,7 +2685,7 @@ function putbaraij(task_:: MSKtask,i_:: Int32,j_:: Int32,sub_:: Array{Int64},wei
   res = @msk_ccall( "putbaraij",Int32,(Ptr{Void},Int32,Int32,Int64,Ptr{Int64},Ptr{Float64},),task_.task,i_-1,j_-1,num_,sub_ .- 1,weights_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2714,7 +2714,7 @@ function putbarcblocktriplet(task_:: MSKtask,num_:: Int64,subj_:: Array{Int32},s
   res = @msk_ccall( "putbarcblocktriplet",Int32,(Ptr{Void},Int64,Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,num_,subj_ .- 1,subk_ .- 1,subl_ .- 1,valjkl_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2724,7 +2724,7 @@ function putbarcj(task_:: MSKtask,j_:: Int32,sub_:: Array{Int64},weights_:: Arra
   res = @msk_ccall( "putbarcj",Int32,(Ptr{Void},Int32,Int64,Ptr{Int64},Ptr{Float64},),task_.task,j_-1,num_,sub_ .- 1,weights_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2738,7 +2738,7 @@ function putbarsj(task_:: MSKtask,whichsol_:: Int32,j_:: Int32,barsj_:: Array{Fl
   res = @msk_ccall( "putbarsj",Int32,(Ptr{Void},Int32,Int32,Ptr{Float64},),task_.task,whichsol_,j_-1,barsj_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2747,7 +2747,7 @@ function putbarvarname(task_:: MSKtask,j_:: Int32,name_:: String)
   res = @msk_ccall( "putbarvarname",Int32,(Ptr{Void},Int32,Ptr{UInt8},),task_.task,j_-1,bytestring(name_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2761,7 +2761,7 @@ function putbarxj(task_:: MSKtask,whichsol_:: Int32,j_:: Int32,barxj_:: Array{Fl
   res = @msk_ccall( "putbarxj",Int32,(Ptr{Void},Int32,Int32,Ptr{Float64},),task_.task,whichsol_,j_-1,barxj_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2770,7 +2770,7 @@ function putbound(task_:: MSKtask,accmode_:: Int32,i_:: Int32,bk_:: Int32,bl_:: 
   res = @msk_ccall( "putbound",Int32,(Ptr{Void},Int32,Int32,Int32,Float64,Float64,),task_.task,accmode_,i_-1,bk_,bl_,bu_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2780,7 +2780,7 @@ function putboundlist(task_:: MSKtask,accmode_:: Int32,sub_:: Array{Int32},bk_::
   res = @msk_ccall( "putboundlist",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Int32},Ptr{Float64},Ptr{Float64},),task_.task,accmode_,num_,sub_ .- 1,bk_,bl_,bu_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2804,7 +2804,7 @@ function putboundslice(task_:: MSKtask,con_:: Int32,first_:: Int32,last_:: Int32
   res = @msk_ccall( "putboundslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Int32},Ptr{Float64},Ptr{Float64},),task_.task,con_,first_-1,last_-1,bk_,bl_,bu_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2813,7 +2813,7 @@ function putcfix(task_:: MSKtask,cfix_:: Float64)
   res = @msk_ccall( "putcfix",Int32,(Ptr{Void},Float64,),task_.task,cfix_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2822,7 +2822,7 @@ function putcj(task_:: MSKtask,j_:: Int32,cj_:: Float64)
   res = @msk_ccall( "putcj",Int32,(Ptr{Void},Int32,Float64,),task_.task,j_-1,cj_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2832,7 +2832,7 @@ function putclist(task_:: MSKtask,subj_:: Array{Int32},val_:: Array{Float64})
   res = @msk_ccall( "putclist",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Float64},),task_.task,num_,subj_ .- 1,val_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2841,7 +2841,7 @@ function putconbound(task_:: MSKtask,i_:: Int32,bk_:: Int32,bl_:: Float64,bu_:: 
   res = @msk_ccall( "putconbound",Int32,(Ptr{Void},Int32,Int32,Float64,Float64,),task_.task,i_-1,bk_,bl_,bu_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2851,7 +2851,7 @@ function putconboundlist(task_:: MSKtask,sub_:: Array{Int32},bkc_:: Array{Int32}
   res = @msk_ccall( "putconboundlist",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},Ptr{Float64},Ptr{Float64},),task_.task,num_,sub_ .- 1,bkc_,blc_,buc_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2875,7 +2875,7 @@ function putconboundslice(task_:: MSKtask,first_:: Int32,last_:: Int32,bk_:: Arr
   res = @msk_ccall( "putconboundslice",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},Ptr{Float64},),task_.task,first_-1,last_-1,bk_,bl_,bu_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2885,7 +2885,7 @@ function putcone(task_:: MSKtask,k_:: Int32,conetype_:: Int32,conepar_:: Float64
   res = @msk_ccall( "putcone",Int32,(Ptr{Void},Int32,Int32,Float64,Int32,Ptr{Int32},),task_.task,k_-1,conetype_,conepar_,nummem_,submem_ .- 1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2894,7 +2894,7 @@ function putconename(task_:: MSKtask,j_:: Int32,name_:: String)
   res = @msk_ccall( "putconename",Int32,(Ptr{Void},Int32,Ptr{UInt8},),task_.task,j_-1,bytestring(name_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2903,7 +2903,7 @@ function putconname(task_:: MSKtask,i_:: Int32,name_:: String)
   res = @msk_ccall( "putconname",Int32,(Ptr{Void},Int32,Ptr{UInt8},),task_.task,i_-1,bytestring(name_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2917,7 +2917,7 @@ function putcslice(task_:: MSKtask,first_:: Int32,last_:: Int32,slice_:: Array{F
   res = @msk_ccall( "putcslice",Int32,(Ptr{Void},Int32,Int32,Ptr{Float64},),task_.task,first_-1,last_-1,slice_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2926,7 +2926,7 @@ function putdouparam(task_:: MSKtask,param_:: Int32,parvalue_:: Float64)
   res = @msk_ccall( "putdouparam",Int32,(Ptr{Void},Int32,Float64,),task_.task,param_,parvalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2935,7 +2935,7 @@ function putintparam(task_:: MSKtask,param_:: Int32,parvalue_:: Int32)
   res = @msk_ccall( "putintparam",Int32,(Ptr{Void},Int32,Int32,),task_.task,param_,parvalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2944,7 +2944,7 @@ function putmaxnumanz(task_:: MSKtask,maxnumanz_:: Int64)
   res = @msk_ccall( "putmaxnumanz",Int32,(Ptr{Void},Int64,),task_.task,maxnumanz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2953,7 +2953,7 @@ function putmaxnumbarvar(task_:: MSKtask,maxnumbarvar_:: Int32)
   res = @msk_ccall( "putmaxnumbarvar",Int32,(Ptr{Void},Int32,),task_.task,maxnumbarvar_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2962,7 +2962,7 @@ function putmaxnumcon(task_:: MSKtask,maxnumcon_:: Int32)
   res = @msk_ccall( "putmaxnumcon",Int32,(Ptr{Void},Int32,),task_.task,maxnumcon_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2971,7 +2971,7 @@ function putmaxnumcone(task_:: MSKtask,maxnumcone_:: Int32)
   res = @msk_ccall( "putmaxnumcone",Int32,(Ptr{Void},Int32,),task_.task,maxnumcone_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2980,7 +2980,7 @@ function putmaxnumqnz(task_:: MSKtask,maxnumqnz_:: Int64)
   res = @msk_ccall( "putmaxnumqnz",Int32,(Ptr{Void},Int64,),task_.task,maxnumqnz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2989,7 +2989,7 @@ function putmaxnumvar(task_:: MSKtask,maxnumvar_:: Int32)
   res = @msk_ccall( "putmaxnumvar",Int32,(Ptr{Void},Int32,),task_.task,maxnumvar_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -2998,7 +2998,7 @@ function putnadouparam(task_:: MSKtask,paramname_:: String,parvalue_:: Float64)
   res = @msk_ccall( "putnadouparam",Int32,(Ptr{Void},Ptr{UInt8},Float64,),task_.task,bytestring(paramname_),parvalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3007,7 +3007,7 @@ function putnaintparam(task_:: MSKtask,paramname_:: String,parvalue_:: Int32)
   res = @msk_ccall( "putnaintparam",Int32,(Ptr{Void},Ptr{UInt8},Int32,),task_.task,bytestring(paramname_),parvalue_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3015,7 +3015,7 @@ function putnastrparam(task_:: MSKtask,paramname_:: String,parvalue_:: String)
   res = @msk_ccall( "putnastrparam",Int32,(Ptr{Void},Ptr{UInt8},Ptr{UInt8},),task_.task,bytestring(paramname_),bytestring(parvalue_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3023,7 +3023,7 @@ function putobjname(task_:: MSKtask,objname_:: String)
   res = @msk_ccall( "putobjname",Int32,(Ptr{Void},Ptr{UInt8},),task_.task,bytestring(objname_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3031,7 +3031,7 @@ function putobjsense(task_:: MSKtask,sense_:: Int32)
   res = @msk_ccall( "putobjsense",Int32,(Ptr{Void},Int32,),task_.task,sense_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3039,7 +3039,7 @@ function putparam(task_:: MSKtask,parname_:: String,parvalue_:: String)
   res = @msk_ccall( "putparam",Int32,(Ptr{Void},Ptr{UInt8},Ptr{UInt8},),task_.task,bytestring(parname_),bytestring(parvalue_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3049,7 +3049,7 @@ function putqcon(task_:: MSKtask,qcsubk_:: Array{Int32},qcsubi_:: Array{Int32},q
   res = @msk_ccall( "putqcon",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,numqcnz_,qcsubk_ .- 1,qcsubi_ .- 1,qcsubj_ .- 1,qcval_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3067,7 +3067,7 @@ function putqconk(task_:: MSKtask,k_:: Int32,qcsubi_:: Array{Int32},qcsubj_:: Ar
   res = @msk_ccall( "putqconk",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,k_-1,numqcnz_,qcsubi_ .- 1,qcsubj_ .- 1,qcval_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3085,7 +3085,7 @@ function putqobj(task_:: MSKtask,qosubi_:: Array{Int32},qosubj_:: Array{Int32},q
   res = @msk_ccall( "putqobj",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,numqonz_,qosubi_ .- 1,qosubj_ .- 1,qoval_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3094,7 +3094,7 @@ function putqobjij(task_:: MSKtask,i_:: Int32,j_:: Int32,qoij_:: Float64)
   res = @msk_ccall( "putqobjij",Int32,(Ptr{Void},Int32,Int32,Float64,),task_.task,i_-1,j_-1,qoij_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3107,7 +3107,7 @@ function putskc(task_:: MSKtask,whichsol_:: Int32,skc_:: Array{Int32})
   res = @msk_ccall( "putskc",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,whichsol_,skc_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3121,7 +3121,7 @@ function putskcslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "putskcslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Int32},),task_.task,whichsol_,first_-1,last_-1,skc_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3134,7 +3134,7 @@ function putskx(task_:: MSKtask,whichsol_:: Int32,skx_:: Array{Int32})
   res = @msk_ccall( "putskx",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,whichsol_,skx_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3148,7 +3148,7 @@ function putskxslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "putskxslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Int32},),task_.task,whichsol_,first_-1,last_-1,skx_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3162,7 +3162,7 @@ function putslc(task_:: MSKtask,whichsol_:: Int32,slc_:: Array{Float64})
   res = @msk_ccall( "putslc",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,slc_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3176,7 +3176,7 @@ function putslcslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "putslcslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,slc_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3190,7 +3190,7 @@ function putslx(task_:: MSKtask,whichsol_:: Int32,slx_:: Array{Float64})
   res = @msk_ccall( "putslx",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,slx_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3204,7 +3204,7 @@ function putslxslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "putslxslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,slx_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3218,7 +3218,7 @@ function putsnx(task_:: MSKtask,whichsol_:: Int32,sux_:: Array{Float64})
   res = @msk_ccall( "putsnx",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,sux_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3232,7 +3232,7 @@ function putsnxslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "putsnxslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,snx_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3241,7 +3241,7 @@ function putsolution(task_:: MSKtask,whichsol_:: Int32,skc_:: Array{Int32},skx_:
   res = @msk_ccall( "putsolution",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},),task_.task,whichsol_,skc_,skx_,skn_,xc_,xx_,y_,slc_,suc_,slx_,sux_,snx_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3250,7 +3250,7 @@ function putsolutioni(task_:: MSKtask,accmode_:: Int32,i_:: Int32,whichsol_:: In
   res = @msk_ccall( "putsolutioni",Int32,(Ptr{Void},Int32,Int32,Int32,Int32,Float64,Float64,Float64,Float64,),task_.task,accmode_,i_-1,whichsol_,sk_,x_,sl_,su_,sn_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3259,7 +3259,7 @@ function putsolutionyi(task_:: MSKtask,i_:: Int32,whichsol_:: Int32,y_:: Float64
   res = @msk_ccall( "putsolutionyi",Int32,(Ptr{Void},Int32,Int32,Float64,),task_.task,i_-1,whichsol_,y_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3267,7 +3267,7 @@ function putstrparam(task_:: MSKtask,param_:: Int32,parvalue_:: String)
   res = @msk_ccall( "putstrparam",Int32,(Ptr{Void},Int32,Ptr{UInt8},),task_.task,param_,bytestring(parvalue_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3281,7 +3281,7 @@ function putsuc(task_:: MSKtask,whichsol_:: Int32,suc_:: Array{Float64})
   res = @msk_ccall( "putsuc",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,suc_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3295,7 +3295,7 @@ function putsucslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "putsucslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,suc_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3309,7 +3309,7 @@ function putsux(task_:: MSKtask,whichsol_:: Int32,sux_:: Array{Float64})
   res = @msk_ccall( "putsux",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,sux_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3323,7 +3323,7 @@ function putsuxslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: In
   res = @msk_ccall( "putsuxslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,sux_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3331,7 +3331,7 @@ function puttaskname(task_:: MSKtask,taskname_:: String)
   res = @msk_ccall( "puttaskname",Int32,(Ptr{Void},Ptr{UInt8},),task_.task,bytestring(taskname_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3340,7 +3340,7 @@ function putvarbound(task_:: MSKtask,j_:: Int32,bk_:: Int32,bl_:: Float64,bu_:: 
   res = @msk_ccall( "putvarbound",Int32,(Ptr{Void},Int32,Int32,Float64,Float64,),task_.task,j_-1,bk_,bl_,bu_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3350,7 +3350,7 @@ function putvarboundlist(task_:: MSKtask,sub_:: Array{Int32},bkx_:: Array{Int32}
   res = @msk_ccall( "putvarboundlist",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},Ptr{Float64},Ptr{Float64},),task_.task,num_,sub_ .- 1,bkx_,blx_,bux_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3374,7 +3374,7 @@ function putvarboundslice(task_:: MSKtask,first_:: Int32,last_:: Int32,bk_:: Arr
   res = @msk_ccall( "putvarboundslice",Int32,(Ptr{Void},Int32,Int32,Ptr{Int32},Ptr{Float64},Ptr{Float64},),task_.task,first_-1,last_-1,bk_,bl_,bu_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3383,7 +3383,7 @@ function putvarbranchorder(task_:: MSKtask,j_:: Int32,priority_:: Int32,directio
   res = @msk_ccall( "putvarbranchorder",Int32,(Ptr{Void},Int32,Int32,Int32,),task_.task,j_-1,priority_,direction_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3392,7 +3392,7 @@ function putvarname(task_:: MSKtask,j_:: Int32,name_:: String)
   res = @msk_ccall( "putvarname",Int32,(Ptr{Void},Int32,Ptr{UInt8},),task_.task,j_-1,bytestring(name_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3401,7 +3401,7 @@ function putvartype(task_:: MSKtask,j_:: Int32,vartype_:: Int32)
   res = @msk_ccall( "putvartype",Int32,(Ptr{Void},Int32,Int32,),task_.task,j_-1,vartype_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3411,7 +3411,7 @@ function putvartypelist(task_:: MSKtask,subj_:: Array{Int32},vartype_:: Array{In
   res = @msk_ccall( "putvartypelist",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},),task_.task,num_,subj_ .- 1,vartype_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3421,7 +3421,7 @@ function putxc(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "putxc",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,__tmp_var_1)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_1)
 end
@@ -3436,7 +3436,7 @@ function putxcslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: Int
   res = @msk_ccall( "putxcslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,xc_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3450,7 +3450,7 @@ function putxx(task_:: MSKtask,whichsol_:: Int32,xx_:: Array{Float64})
   res = @msk_ccall( "putxx",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,xx_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3464,7 +3464,7 @@ function putxxslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: Int
   res = @msk_ccall( "putxxslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,xx_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3478,7 +3478,7 @@ function puty(task_:: MSKtask,whichsol_:: Int32,y_:: Array{Float64})
   res = @msk_ccall( "puty",Int32,(Ptr{Void},Int32,Ptr{Float64},),task_.task,whichsol_,y_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3492,7 +3492,7 @@ function putyslice(task_:: MSKtask,whichsol_:: Int32,first_:: Int32,last_:: Int3
   res = @msk_ccall( "putyslice",Int32,(Ptr{Void},Int32,Int32,Int32,Ptr{Float64},),task_.task,whichsol_,first_-1,last_-1,y_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3500,7 +3500,7 @@ function readbranchpriorities(task_:: MSKtask,filename_:: String)
   res = @msk_ccall( "readbranchpriorities",Int32,(Ptr{Void},Ptr{UInt8},),task_.task,bytestring(filename_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3508,7 +3508,7 @@ function readdata(task_:: MSKtask,filename_:: String)
   res = @msk_ccall( "readdataautoformat",Int32,(Ptr{Void},Ptr{UInt8},),task_.task,bytestring(filename_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3516,7 +3516,7 @@ function readdataformat(task_:: MSKtask,filename_:: String,format_:: Int32,compr
   res = @msk_ccall( "readdataformat",Int32,(Ptr{Void},Ptr{UInt8},Int32,Int32,),task_.task,bytestring(filename_),format_,compress_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3524,7 +3524,7 @@ function readparamfile(task_:: MSKtask)
   res = @msk_ccall( "readparamfile",Int32,(Ptr{Void},),task_.task)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3532,7 +3532,7 @@ function readsolution(task_:: MSKtask,whichsol_:: Int32,filename_:: String)
   res = @msk_ccall( "readsolution",Int32,(Ptr{Void},Int32,Ptr{UInt8},),task_.task,whichsol_,bytestring(filename_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3540,7 +3540,7 @@ function readsummary(task_:: MSKtask,whichstream_:: Int32)
   res = @msk_ccall( "readsummary",Int32,(Ptr{Void},Int32,),task_.task,whichstream_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3548,7 +3548,7 @@ function readtask(task_:: MSKtask,filename_:: String)
   res = @msk_ccall( "readtask",Int32,(Ptr{Void},Ptr{UInt8},),task_.task,bytestring(filename_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3578,7 +3578,7 @@ function relaxprimal(task_:: MSKtask,wlc_:: Array{Float64},wuc_:: Array{Float64}
   res = @msk_ccall( "relaxprimal",Int32,(Ptr{Void},Ptr{Ptr{Void}},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},),task_.task,relaxedtask_,wlc_,wuc_,wlx_,wux_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(MSKtask,relaxedtask_[1]))
 end
@@ -3589,7 +3589,7 @@ function removebarvars(task_:: MSKtask,subset_:: Array{Int32})
   res = @msk_ccall( "removebarvars",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,num_,subset_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3599,7 +3599,7 @@ function removecones(task_:: MSKtask,subset_:: Array{Int32})
   res = @msk_ccall( "removecones",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,num_,subset_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3609,7 +3609,7 @@ function removecons(task_:: MSKtask,subset_:: Array{Int32})
   res = @msk_ccall( "removecons",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,num_,subset_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3619,7 +3619,7 @@ function removevars(task_:: MSKtask,subset_:: Array{Int32})
   res = @msk_ccall( "removevars",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,num_,subset_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3628,7 +3628,7 @@ function resizetask(task_:: MSKtask,maxnumcon_:: Int32,maxnumvar_:: Int32,maxnum
   res = @msk_ccall( "resizetask",Int32,(Ptr{Void},Int32,Int32,Int32,Int64,Int64,),task_.task,maxnumcon_,maxnumvar_,maxnumcone_,maxnumanz_,maxnumqnz_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3636,7 +3636,7 @@ function sensitivityreport(task_:: MSKtask,whichstream_:: Int32)
   res = @msk_ccall( "sensitivityreport",Int32,(Ptr{Void},Int32,),task_.task,whichstream_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3644,7 +3644,7 @@ function setdefaults(task_:: MSKtask)
   res = @msk_ccall( "setdefaults",Int32,(Ptr{Void},),task_.task)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3653,7 +3653,7 @@ function sktostr(task_:: MSKtask,sk_:: Int32)
   res = @msk_ccall( "sktostr",Int32,(Ptr{Void},Int32,Ptr{Uint8},),task_.task,sk_,str_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(str_))
 end
@@ -3663,7 +3663,7 @@ function solstatostr(task_:: MSKtask,solsta_:: Int32)
   res = @msk_ccall( "solstatostr",Int32,(Ptr{Void},Int32,Ptr{Uint8},),task_.task,solsta_,str_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (bytestring(str_))
 end
@@ -3673,7 +3673,7 @@ function solutiondef(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "solutiondef",Int32,(Ptr{Void},Int32,Ptr{Int32},),task_.task,whichsol_,isdef_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Bool,isdef_[1]))
 end
@@ -3682,7 +3682,7 @@ function solutionsummary(task_:: MSKtask,whichstream_:: Int32)
   res = @msk_ccall( "solutionsummary",Int32,(Ptr{Void},Int32,),task_.task,whichstream_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3702,7 +3702,7 @@ function solvewithbasis(task_:: MSKtask,transp_:: Int32,numnz_:: Int32,sub_:: Ar
   res = @msk_ccall( "solvewithbasis",Int32,(Ptr{Void},Int32,Ptr{Int32},Ptr{Int32},Ptr{Float64},),task_.task,transp_,__tmp_var_0,sub_ .- 1,val_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (__tmp_var_0[1])
 end
@@ -3711,7 +3711,7 @@ function startstat(task_:: MSKtask)
   res = @msk_ccall( "startstat",Int32,(Ptr{Void},),task_.task)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3719,7 +3719,7 @@ function stopstat(task_:: MSKtask)
   res = @msk_ccall( "stopstat",Int32,(Ptr{Void},),task_.task)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3728,7 +3728,7 @@ function strtoconetype(task_:: MSKtask,str_:: String)
   res = @msk_ccall( "strtoconetype",Int32,(Ptr{Void},Ptr{UInt8},Ptr{Int32},),task_.task,bytestring(str_),conetype_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,conetype_[1]))
 end
@@ -3738,7 +3738,7 @@ function strtosk(task_:: MSKtask,str_:: String)
   res = @msk_ccall( "strtosk",Int32,(Ptr{Void},Ptr{UInt8},Ptr{Int32},),task_.task,bytestring(str_),sk_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
   (convert(Int32,sk_[1]))
 end
@@ -3747,7 +3747,7 @@ function updatesolutioninfo(task_:: MSKtask,whichsol_:: Int32)
   res = @msk_ccall( "updatesolutioninfo",Int32,(Ptr{Void},Int32,),task_.task,whichsol_)
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3755,7 +3755,7 @@ function writebranchpriorities(task_:: MSKtask,filename_:: String)
   res = @msk_ccall( "writebranchpriorities",Int32,(Ptr{Void},Ptr{UInt8},),task_.task,bytestring(filename_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3763,7 +3763,7 @@ function writedata(task_:: MSKtask,filename_:: String)
   res = @msk_ccall( "writedata",Int32,(Ptr{Void},Ptr{UInt8},),task_.task,bytestring(filename_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3771,7 +3771,7 @@ function writeparamfile(task_:: MSKtask,filename_:: String)
   res = @msk_ccall( "writeparamfile",Int32,(Ptr{Void},Ptr{UInt8},),task_.task,bytestring(filename_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3779,7 +3779,7 @@ function writesolution(task_:: MSKtask,whichsol_:: Int32,filename_:: String)
   res = @msk_ccall( "writesolution",Int32,(Ptr{Void},Int32,Ptr{UInt8},),task_.task,whichsol_,bytestring(filename_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
@@ -3787,21 +3787,21 @@ function writetask(task_:: MSKtask,filename_:: String)
   res = @msk_ccall( "writetask",Int32,(Ptr{Void},Ptr{UInt8},),task_.task,bytestring(filename_))
   if res != MSK_RES_OK
     msg = getlasterror(task_)
-    throw (MosekError(res,msg))
+    throw(MosekError(res,msg))
   end
 end
 
 function checkinlicense(env_:: MSKenv,feature_:: Int32)
   res = @msk_ccall( "checkinlicense",Int32,(Ptr{Void},Int32,),env_.env,feature_)
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
 end
 
 function checkoutlicense(env_:: MSKenv,feature_:: Int32)
   res = @msk_ccall( "checkoutlicense",Int32,(Ptr{Void},Int32,),env_.env,feature_)
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
 end
 
@@ -3809,7 +3809,7 @@ echointro{T1}(env:: MSKenv,longver:: T1) = echointro(env,@compat(Int32(longver))
 function echointro(env_:: MSKenv,longver_:: Int32)
   res = @msk_ccall( "echointro",Int32,(Ptr{Void},Int32,),env_.env,longver_)
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
 end
 
@@ -3819,7 +3819,7 @@ function getbuildinfo()
   buildtool_ = zeros(Uint8,MSK_MAX_STR_LEN)
   res = @msk_ccall( "getbuildinfo",Int32,(Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},),buildstate_,builddate_,buildtool_)
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
   (bytestring(buildstate_),bytestring(builddate_),bytestring(buildtool_))
 end
@@ -3829,7 +3829,7 @@ function getcodedesc(code_:: Int32)
   str_ = zeros(Uint8,MSK_MAX_STR_LEN)
   res = @msk_ccall( "getcodedesc",Int32,(Int32,Ptr{Uint8},Ptr{Uint8},),code_,symname_,str_)
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
   (bytestring(symname_),bytestring(str_))
 end
@@ -3841,7 +3841,7 @@ function getversion()
   revision_ = Array(Int32,(1,))
   res = @msk_ccall( "getversion",Int32,(Ptr{Int32},Ptr{Int32},Ptr{Int32},Ptr{Int32},),major_,minor_,build_,revision_)
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
   (convert(Int32,major_[1]),convert(Int32,minor_[1]),convert(Int32,build_[1]),convert(Int32,revision_[1]))
 end
@@ -3849,7 +3849,7 @@ end
 function licensecleanup()
   res = @msk_ccall( "licensecleanup",Int32,())
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
 end
 
@@ -3857,14 +3857,14 @@ linkfiletostream{T3}(env:: MSKenv,whichstream:: Int32,filename:: String,append::
 function linkfiletostream(env_:: MSKenv,whichstream_:: Int32,filename_:: String,append_:: Int32)
   res = @msk_ccall( "linkfiletoenvstream",Int32,(Ptr{Void},Int32,Ptr{UInt8},Int32,),env_.env,whichstream_,bytestring(filename_),append_)
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
 end
 
 function putdllpath(env_:: MSKenv,dllpath_:: String)
   res = @msk_ccall( "putdllpath",Int32,(Ptr{Void},Ptr{UInt8},),env_.env,bytestring(dllpath_))
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
 end
 
@@ -3872,7 +3872,7 @@ putkeepdlls{T1}(env:: MSKenv,keepdlls:: T1) = putkeepdlls(env,@compat(Int32(keep
 function putkeepdlls(env_:: MSKenv,keepdlls_:: Int32)
   res = @msk_ccall( "putkeepdlls",Int32,(Ptr{Void},Int32,),env_.env,keepdlls_)
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
 end
 
@@ -3885,7 +3885,7 @@ function putlicensecode(env_:: MSKenv,code_:: Array{Int32})
   end
   res = @msk_ccall( "putlicensecode",Int32,(Ptr{Void},Ptr{Int32},),env_.env,code_)
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
 end
 
@@ -3893,14 +3893,14 @@ putlicensedebug{T1}(env:: MSKenv,licdebug:: T1) = putlicensedebug(env,@compat(In
 function putlicensedebug(env_:: MSKenv,licdebug_:: Int32)
   res = @msk_ccall( "putlicensedebug",Int32,(Ptr{Void},Int32,),env_.env,licdebug_)
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
 end
 
 function putlicensepath(env_:: MSKenv,licensepath_:: String)
   res = @msk_ccall( "putlicensepath",Int32,(Ptr{Void},Ptr{UInt8},),env_.env,bytestring(licensepath_))
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
 end
 
@@ -3908,7 +3908,7 @@ putlicensewait{T1}(env:: MSKenv,licwait:: T1) = putlicensewait(env,@compat(Int32
 function putlicensewait(env_:: MSKenv,licwait_:: Int32)
   res = @msk_ccall( "putlicensewait",Int32,(Ptr{Void},Int32,),env_.env,licwait_)
   if res != 0
-    throw (MosekError(res,""))
+    throw(MosekError(res,""))
   end
 end
 


### PR DESCRIPTION
I was getting lots of warnings like this one:

```bash
WARNING: deprecated syntax "f (" at /Users/ericdavies/.julia/v0.4/Mosek/src/msk_callback.jl:7.
Use "f(" instead.
```

Now they're gone!