### PR TITLE
RFC: fix signs on MathProgBase conic duals

### DIFF
--- a/src/MosekSolverInterface.jl
+++ b/src/MosekSolverInterface.jl
@@ -832,16 +832,12 @@ function getcondual(m::MosekMathProgModel,soldef::Int32)
         map(1:m.numcon) do k
             const j = m.conslack[k]
             const i = m.conmap[k]
-            if     (j == 0) 
-                if bkc[i] in [ MSK_BK_LO, MSK_BK_UP ]
-                    y[i]
-                else                    
-                    -y[i]
-                end
+            if     (j == 0)
+                y[i]
             elseif (j >  0) 
-                -snx[j]
+                snx[j]
             else            
-                -bars[-j][m.barconij[k]]
+                bars[-j][m.barconij[k]]
             end
         end
     end

--- a/test/mathprogtest.jl
+++ b/test/mathprogtest.jl
@@ -16,5 +16,6 @@ socptest(MosekSolver())
 mixintprogtest(MosekSolver())
 convexnlptest(MosekSolver())
 coniclineartest(MosekSolver(),duals=true)
+conicSOCtest(MosekSolver(),duals=true)
 
 


### PR DESCRIPTION
@ulfworsoe, this gets Mosek passing the updated dual tests in MathProgBase: https://github.com/JuliaOpt/MathProgBase.jl/pull/82
I tried to update ``mathprogtestextra.jl``, but I had trouble with the SDP constraint. I'm trying to check dual feasibility via our [definition](http://mathprogbasejl.readthedocs.org/en/latest/conic.html) of the primal-dual pair.
CC @kaarthiksundar 