### PR TITLE
Allow traditional Mosek variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ MathProgBase interface
 
 Mosek implements the solver-independent [MathProgBase](https://github.com/JuliaOpt/MathProgBase.jl) interface,
 and so can be used within modeling software like [JuMP](https://github.com/JuliaOpt/JuMP.jl).
-The solver object is called ``MosekSolver``. Parameters are accepted and mirror the names in the Mosek documentation, except for the ``MSK_[I|D|S]PAR`` prefix.
-For example, you can suppress output by saying ``MosekSolver(LOG=0)``, where ``LOG`` corresponds to the [MSK_IPAR_LOG](http://docs.mosek.com/7.0/capi/MSK_IPAR_LOG.html) parameter.
-The type of the parameter is inferred by the provided value.
+The solver object is called ``MosekSolver``. Parameters are accepted and mirror the names in the Mosek documentation but the ``MSK_[I|D|S]PAR`` prefix is optional.
+For example, you can suppress output by either saying ``MosekSolver(MSK_IPAR_LOG=0)`` or ``MosekSolver(LOG=0)``, where ``LOG`` corresponds to the [MSK_IPAR_LOG](http://docs.mosek.com/7.0/capi/MSK_IPAR_LOG.html) parameter.
+When the prefix is excluded the type of the parameter is inferred by the provided value.
 

--- a/src/MosekSolverInterface.jl
+++ b/src/MosekSolverInterface.jl
@@ -109,18 +109,25 @@ function loadoptions!(m::MosekMathProgModel)
   printstream(msg::AbstractString) = print(msg)
 
   putstreamfunc(m.task,MSK_STREAM_LOG,printstream)
-  for (o,val) in m.options
-      if isa(val, Integer)
-          parname = "MSK_IPAR_$o"
+  for (option,val) in m.options
+      parname = string(option)
+      if startswith(parname, "MSK_IPAR_")
+          putnaintparam(m.task, parname, convert(Integer, val))
+      elseif startswith(parname, "MSK_DPAR_")
+          putnadouparam(m.task, parname, convert(AbstractFloat, val))
+      elseif startswith(parname, "MSK_SPAR_")
+          putnastrparam(m.task, parname, convert(AbstractString, val))
+      elseif isa(val, Integer)
+          parname = "MSK_IPAR_$parname"
           putnaintparam(m.task, parname, val)
       elseif isa(val, AbstractFloat)
-          parname = "MSK_DPAR_$o"
+          parname = "MSK_DPAR_$parname"
           putnadouparam(m.task, parname, val)
       elseif isa(val, AbstractString)
-          parname = "MSK_SPAR_$o"
+          parname = "MSK_SPAR_$parname"
           putnastrparam(m.task, parname, val)
       else
-          error("Value $val for parameter $o has unrecognized type")
+          error("Value $val for parameter $option has unrecognized type")
       end
   end
 end


### PR DESCRIPTION
Convenience change which allows users to use the Mosek C API option names.