### PR TITLE
fixes for MPB 0.4 transition

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.3.2+ 0.5.0-
-MathProgBase 0.3.7 0.4.0-
+julia 0.4
+MathProgBase 0.4 0.5-
 Compat

--- a/src/MosekConicInterface.jl
+++ b/src/MosekConicInterface.jl
@@ -1,13 +1,13 @@
-msk_accepted_cones = [:Free,
-                      :Zero,
-                      :NonNeg,
-                      :NonPos,
-                      :SOC,
-                      :SOCRotated,
-                      :SDP ]
+const msk_accepted_cones = [:Free,
+                            :Zero,
+                            :NonNeg,
+                            :NonPos,
+                            :SOC,
+                            :SOCRotated,
+                            :SDP ]
 
 
-
+MathProgBase.supportedcones(::MosekSolver) = msk_accepted_cones
 
 
 
@@ -316,12 +316,12 @@ function MathProgBase.loadproblem!(m::MosekMathProgConicModel,
                     firstcon   = conptr
                     lastcon    = conptr+n-1
                     barslackj  = barvarptr
-                    d = int32(sqrt(.25+2*length(idxs))-0.5)
+                    d = round(Int32,sqrt(.25+2*length(idxs))-0.5)
 
                     bk[firstcon:lastcon] = Mosek.MSK_BK_FX
 
                     barvardim[barvarptr] = d
-                    appendbarvars(m.task, Int32[d])
+                    Mosek.appendbarvars(m.task, Int32[d])
 
                     conptr += n
                     barvarptr += 1
@@ -330,8 +330,8 @@ function MathProgBase.loadproblem!(m::MosekMathProgConicModel,
                         for vj in 1:d
                             for vi in vj:d
                                 cof = (if vj == vi 1.0 else 0.5 end )
-                                const matidx = appendsparsesymmat(m.task,d,Int32[vi],Int32[vj],Float64[cof])
-                                putbaraij(m.task,i,barslackj,Int64[matidx],Float64[-1.0])
+                                const matidx = Mosek.appendsparsesymmat(m.task,d,Int32[vi],Int32[vj],Float64[cof])
+                                Mosek.putbaraij(m.task,i,barslackj,Int64[matidx],Float64[-1.0])
                                 barconij[i] = i-firstcon+1
                                 i += 1
                             end
@@ -427,7 +427,7 @@ end
 function MathProgBase.getsolution(m::MosekMathProgConicModel)
     sol = getsoldef(m.task)
     if sol < 0
-        throw(Mosek.MosekMathProgModelError("No solution available"))
+        throw(MosekMathProgModelError("No solution available"))
     end
 
     xx = Mosek.getxx(m.task,sol)
@@ -560,12 +560,12 @@ function MathProgBase.setvartype!(m::MosekMathProgConicModel, intvarflag::Vector
     all(x->in(x,[:Cont,:Int,:Bin]), intvarflag) || error("Invalid variable type present")
 
     idxs        = find(i -> m.varmap[i] > 0,1:n)
-    intvarflags = intvarflags[idxs]
+    intvarflags = intvarflag[idxs]
 
-    newbk = Int32[ if (intvarflags[i] == :Bin) Mosek.MSK_BK_RA else m.varbk[idxs[i]] end for i in idxs ]
+    newbk = Int32[ if (intvarflag[i] == :Bin) Mosek.MSK_BK_RA else m.varbk[i] end for i in idxs ]
     newbl = Float64[0.0 for i in idxs ]
-    newbu = Float64[if (intvarflags[i] == :Bin) 1.0 else 0.0 end for i in idxs ]
-    newvt = Int32[if (c == :Cont) Mosek.MSK_VAR_TYPE_CONT else Mosek.MSK_VAR_TYPE_INT end for c in intvarflag[idxs] ]
+    newbu = Float64[if (intvarflag[i] == :Bin) 1.0 else 0.0 end for i in idxs ]
+    newvt = Int32[if (c == :Cont) Mosek.MSK_VAR_TYPE_CONT else Mosek.MSK_VAR_TYPE_INT end for c in intvarflags ]
 
     Mosek.putvartypelist(m.task,m.varmap[idxs],newvt)
     Mosek.putvarboundlist(m.task,m.varmap[idxs],newbk,newbl,newbu)

--- a/src/MosekLPQCQPInterface.jl
+++ b/src/MosekLPQCQPInterface.jl
@@ -616,7 +616,7 @@ function MathProgBase.setwarmstart!(m::MosekLinearQuadraticModel, v::Array{Float
     vals = Array(Float64, n)
     vals[:] = v[1:n]
 
-    nanidxs = find(i -> isnan(vals[i]),vals)
+    nanidxs = find(isnan,vals)
     vals[nanidxs] = 0.0
 
     skx = Int32[ if isnan(vals[i]) Mosek.MSK_SK_UNK else Mosek.MSK_SK_BAS end for i in 1:n ]
@@ -1211,7 +1211,7 @@ MathProgBase.getinfeasibilityray(m::MosekNonlinearModel)                 = MathP
 MathProgBase.getrawsolver(m::MosekNonlinearModel)                        = MathProgBase.getrawsolver(m.m)
 #MathProgBase.getsimplexiter(m::MosekNonlinearModel)                      = MathProgBase.getsimplexiter(m.m)
 MathProgBase.getbarrieriter(m::MosekNonlinearModel)                      = MathProgBase.getbarrieriter(m.m)
-MathProgBase.setwarmstart!(m::MosekNonlinearModel, v::Array{Float64,1})  = MathProgBase.setwarmstart!(m.m)
+MathProgBase.setwarmstart!(m::MosekNonlinearModel, v::Array{Float64,1})  = MathProgBase.setwarmstart!(m.m, v)
 MathProgBase.optimize!(m::MosekNonlinearModel)                           = MathProgBase.optimize!(m.m)
 MathProgBase.status(m::MosekNonlinearModel)                              = MathProgBase.status(m.m)
 #MathProgBase.getobjbound(m::MosekNonlinearModel) = MathProgBase.getobjbound(m.m)

--- a/src/MosekSolverInterface.jl
+++ b/src/MosekSolverInterface.jl
@@ -92,7 +92,7 @@ end
 function getobjval(t::Mosek.MSKtask)
     let sol = getsoldef(t)
         if sol < 0
-            throw(Mosek.MosekMathProgModelError("No solution available"))
+            throw(MosekMathProgModelError("No solution available"))
         else
             Mosek.getprimalobj(t,sol)
         end

--- a/test/apitest.jl
+++ b/test/apitest.jl
@@ -131,7 +131,7 @@ facts("[apitest]") do
         qsubi = [  1,    2,    3,   3   ]
         qsubj = [  1,    2,    3,   1   ]
         qval  = [ -2.0, -2.0, -0.2, 0.2 ]
-        putqconk (task,1, qsubi,qsubj, qval) 
+        putqconk(task,1, qsubi,qsubj, qval)
         putobjsense(task,MSK_OBJECTIVE_SENSE_MINIMIZE)
         optimize(task)
         solutionsummary(task,MSK_STREAM_MSG)


### PR DESCRIPTION
PR against the mpb0.4-impl branch. Here are a few fixes I needed to get Mosek running with JuMP and Convex.jl on their mpb0.4 branches. Tests are still failing in a number of places.

Note that the new version of MPB requires julia 0.4, so it's okay to drop the dependency on the Compat package and all of the ``@compat`` macros.