### PR TITLE
remove debugging output

### DIFF
--- a/src/MosekSolverInterface.jl
+++ b/src/MosekSolverInterface.jl
@@ -49,7 +49,6 @@ function status(t::Mosek.MSKtask, r::Int32)
       prosta = Mosek.getprosta(t,sol)
       solsta = Mosek.getsolsta(t,sol)
 
-      println("r = ",r)
       if     solsta == Mosek.MSK_SOL_STA_DUAL_FEAS ||
           solsta == Mosek.MSK_SOL_STA_PRIM_FEAS ||
           solsta == Mosek.MSK_SOL_STA_NEAR_PRIM_FEAS ||


### PR DESCRIPTION
It looks like this slipped through by accident. The interface is currently printing ``r = 0`` after every solve.