### PR TITLE
unsafe_wrap(String, ...) -> unsafe_string(...)

### DIFF
--- a/src/msk_callback.jl
+++ b/src/msk_callback.jl
@@ -4,7 +4,7 @@ export
 
 function msk_stream_callback_wrapper(userdata::Ptr{Void}, msg :: Ptr{UInt8})
   f = unsafe_pointer_to_objref(userdata) :: Function
-  f(unsafe_wrap(String,msg))
+  f(unsafe_string(msg))
   convert(Int32,0)::Int32
 end
 


### PR DESCRIPTION
`unsafe_string` already exists in Julia v0.5 and `unsafe_wrap(String, ...)` is deprecated in Julia v0.6