### PR TITLE
fix exp cone order, use conic tests

### DIFF
--- a/src/MosekConicInterface.jl
+++ b/src/MosekConicInterface.jl
@@ -307,8 +307,6 @@ function MathProgBase.loadproblem!(m::MosekMathProgConicModel,
                       elseif sym == :NonPos Mosek.MSK_BK_UP
                       end
                 elseif sym in [ :SOC, :SOCRotated, :ExpPrimal ]
-                    firstcon   = conptr
-                    lastcon    = conptr+n-1
                     firstslack = linvarptr
                     lastslack  = linvarptr+n-1
                     conptr += n
@@ -321,11 +319,15 @@ function MathProgBase.loadproblem!(m::MosekMathProgConicModel,
                     # Then add slacks to the rows: b-Ax - s = 0, s in C
                     local bx = zeros(Float64,n)
                     Mosek.putvarboundslice(m.task,Int32(firstslack),Int32(lastslack+1),Mosek.Boundkey[Mosek.MSK_BK_FR for i in 1:n],bx,bx)
-                    Mosek.putaijlist(m.task,Int32[firstcon:lastcon;],Int32[firstslack:lastslack;],-ones(Float64,n))
+                    Mosek.putaijlist(m.task,
+                                     convert(Array{Int32,1},idxs),
+                                     Int32[firstslack:lastslack...],
+                                     -ones(Float64,n))
                     if     sym == :SOC        Mosek.appendcone(m.task, Mosek.MSK_CT_QUAD,  0.0, Int32[firstslack:lastslack;])
                     elseif sym == :SOCRotated Mosek.appendcone(m.task, Mosek.MSK_CT_RQUAD, 0.0, Int32[firstslack:lastslack;])
                     elseif sym == :ExpPrimal  Mosek.appendcone(m.task, Mosek.MSK_CT_PEXP,  0.0, Int32[lastslack:-1:firstslack;])
                     end
+
                 elseif sym == :SDP
                     firstcon   = conptr
                     lastcon    = conptr+n-1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,4 @@ using Base.Test
 include("apitest.jl")
 include("testexamples.jl")
 include("testshow.jl")
-
+include("test_mathprogbase.jl")

--- a/test/test_mathprogbase.jl
+++ b/test/test_mathprogbase.jl
@@ -23,8 +23,7 @@ function test_mathprogbase(solver)
     @testset "mip" begin
         mixintprogtest(solver)
     end
-
-
+    
     @testset "qp" begin
         #quadprogtest(solver)
         #qpdualtest(solver)
@@ -40,17 +39,17 @@ function test_mathprogbase(solver)
 
     @testset "conic" begin
         coniclineartest(solver, duals=true)
-        # Test conic fallback for LPs
-        #coniclineartest(solver, duals=true)
+        conicSOCtest(solver, duals=true)
+        conicSOCRotatedtest(solver, duals=true)
+        conicSOCINTtest(solver)
+        conicEXPtest(solver, duals=true)
+        conicSDPtest(solver, duals=true)
     end
 
     @testset "linproginterface" begin
         linprogsolvertest(solver)
         linprogsolvertestextra(solver)
-        # Test LP fallback for conics
-        linprogsolvertest(solver)
     end
-
 end
 
 test_mathprogbase(Mosek.MosekSolver(QUIET = true))


### PR DESCRIPTION
reverse order of exp cone from MPB
now the mathprogbase conic tests in MPB succeed
@ulfworsoe @mlubin 