### PR TITLE
Fix info message when no mosek is installed

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -171,7 +171,11 @@ mskbindir =
             open(joinpath(dldir,"new_version"),"r") do f
                 strip(read(f,String))
             end
-        @info("Latest MOSEK version = $new_version, currently installed = $cur_version")
+        if cur_version === nothing
+            @info("Latest MOSEK version = $new_version, nothing currently installed")
+        else
+            @info("Latest MOSEK version = $new_version, currently installed = $cur_version")
+        end
 
         instmethod = "internal"
 


### PR DESCRIPTION
Printing `nothing` does not work on Julia v1.0:
```julia
julia> "$nothing"
ERROR: ArgumentError: `nothing` should not be printed; use `show`, `repr`, or custom output instead.
Stacktrace:
 [1] print(::Base.GenericIOBuffer{Array{UInt8,1}}, ::Nothing) at ./show.jl:566
 [2] #print_to_string#326(::Nothing, ::Function, ::Nothing) at ./strings/io.jl:124
 [3] print_to_string(::Nothing) at ./strings/io.jl:112
 [4] string(::Nothing) at ./strings/io.jl:143
 [5] top-level scope at none:0
```