### PR TITLE
1-indexing for getvarnameindex

### DIFF
--- a/src/msk_functions.jl
+++ b/src/msk_functions.jl
@@ -4949,7 +4949,7 @@ function getvarnameindex(task_:: MSKtask,somename_:: AbstractString)
     msg = getlasterror(task_)
     throw(MosekError(res,msg))
   end
-  (convert(Int32,asgn_[1]),convert(Int32,index_[1]))
+  (convert(Int32, asgn_[1]), convert(Int32, index_[1] + 1))
 end
 
 """


### PR DESCRIPTION
It is shifted by `1` in the b0.9 branch:
https://github.com/JuliaOpt/Mosek.jl/blob/5996662b755779f0c5bf20b4e61eb94af7728f95/src/msk_functions.jl#L4602
I am find with it shifted or not but it needs to be consistent between the two branches for MosekTools to be able to work for both.
@ulfworsoe What should be done ?