### PR TITLE
Fix `ERROR: UndefVarError: Rescode not defined`

### DIFF
--- a/src/MosekConicInterface.jl
+++ b/src/MosekConicInterface.jl
@@ -577,7 +577,7 @@ function MathProgBase.optimize!(m::MosekMathProgConicModel)
         Mosek.solutionsummary(m.task,Mosek.MSK_STREAM_LOG)
     catch err
         if isa(err,Mosek.MosekError)
-            m.lasttrm = Rescode(err.rcode)
+            m.lasttrm = Mosek.Rescode(err.rcode)
         else
             rethrow()
         end


### PR DESCRIPTION
 I'm using Mosek with Convex via MathProgBase on the #b0.9 branch, and I get `ERROR: UndefVarError: Rescode not defined` when an error occurs. Locally, qualifying the function with the module as I've done here fixes the problem, so I assume it's just not exported.