### PR TITLE
Shift indices given to removecones

### DIFF
--- a/src/msk_functions.jl
+++ b/src/msk_functions.jl
@@ -8384,7 +8384,7 @@ removecones(task:: MSKtask,subset:: Vector{T1}) where {T1} = removecones(task,co
 function removecones(task_:: MSKtask,subset_:: Vector{Int32})
   num_ = minimum([ length(subset_) ])
   res = disable_sigint() do
-    @msk_ccall( "removecones",Int32,(Ptr{Nothing},Int32,Ptr{Int32},),task_.task,num_,subset_)
+    @msk_ccall( "removecones",Int32,(Ptr{Nothing},Int32,Ptr{Int32},),task_.task,num_, subset_ .- Int32(1))
   end
   if res != MSK_RES_OK.value
     msg = getlasterror(task_)

--- a/test/apitest.jl
+++ b/test/apitest.jl
@@ -294,6 +294,26 @@ function test_sdo1()
     end
 end
 
+function test_removecones()
+    task = maketask()
+    appendvars(task, 7)
+    appendcone(task, MSK_CT_QUAD, 0.0, [1, 2, 3])
+    appendcone(task, MSK_CT_RQUAD, 0.0, [4, 5, 6, 7])
+    @test getcone(task, 1) == (Mosek.MSK_CT_QUAD, 0.0, 3, Int32[1, 2, 3])
+    @test getconeinfo(task, 1) == (Mosek.MSK_CT_QUAD, 0.0, 3)
+    @test getcone(task, 2) == (Mosek.MSK_CT_RQUAD, 0.0, 4, Int32[4, 5, 6, 7])
+    @test getconeinfo(task, 2) == (Mosek.MSK_CT_RQUAD, 0.0, 4)
+    removecones(task, [1])
+    info = getconeinfo(task, 1)
+    # `info[1]` is Mosek.MSK_CT_QUAD
+    @test_broken info[1] == Mosek.MSK_CT_RQUAD
+    @test info[2:end] == (0.0, 4)
+    cone = getcone(task, 1)
+    # `cone[1]` is Mosek.MSK_CT_QUAD
+    @test_broken cone[1] == Mosek.MSK_CT_RQUAD
+    @test cone[2:end] == (0.0, 4, Int32[4, 5, 6, 7])
+end
+
 @testset "[apitest]" begin
     @testset "lo1" begin
         test_lo1()
@@ -317,6 +337,10 @@ end
 
     @testset "sdo1" begin
         test_sdo1()
+    end
+
+    @testset "removecones" begin
+        test_removecones()
     end
 
 end


### PR DESCRIPTION
`getcone` and `getconeinfo` both shift the cone index from the Julia 1-index to the C 0-index but `removecones` currently does not do it which is inconsistent.
This PR also shifts the index in `removecones` and add tests.
Note that `getcone` and `getconeinfo` return an incorrect cone type `QUAD` instead of the expected `RQUAD`.