### PR TITLE
avoid macos error

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -16,6 +16,7 @@ mskplatform,distroext =
     if     Sys.islinux()   "linux64x86",".tar.bz2"
     elseif Sys.isapple()   "osx64x86",  ".tar.bz2"
     elseif Sys.iswindows() "win64x86",  ".zip"
+    elseif Sys.isapple()   "osx64x86",  ".tar.bz2" #! avoid macos error
     else   error("Platform not supported on AMD64")
     end
   elseif Sys.ARCH == :aarch64


### PR DESCRIPTION
I got an error (that I think was not supposed to happen) when installing Mosek on macos.
```
julia> versioninfo()
Julia Version 1.8.5
Commit 17cfb8e65ea (2023-01-08 06:45 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin21.4.0)
  CPU: 8 × Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-13.0.1 (ORCJIT, skylake)
  Threads: 1 on 8 virtual cores
Environment:
  LD_LIBRARY_PATH = /Users/jakeroth/.julia/v0.6/Pardiso/deps/libpardiso500-MACOS-X86-64.dylib
  JULIA_BINDIR = /Applications/Julia-1.8.app/Contents/Resources/julia/bin/

(@v1.8) pkg> build Mosek
    Building Mosek → `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/ea661427c5951c3de663550b637165ecd38febb2/build.log`
ERROR: Error building `Mosek`:
ERROR: LoadError: Platform not supported on AMD64
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] top-level scope
   @ ~/.julia/packages/Mosek/Gzljt/deps/build.jl:18
 [3] include(fname::String)
   @ Base.MainInclude ./client.jl:476
 [4] top-level scope
   @ none:5
in expression starting at /Users/jakeroth/.julia/packages/Mosek/Gzljt/deps/build.jl:10
```